### PR TITLE
Longform article breaks if no metadata found

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -44,18 +44,21 @@ export function removeEmptyElements(container, selector) {
 
 /**
  * Returns section metadata JSON key:value pairs
- * @param {HTMLDivElement} metadataElement
+ * @param {HTMLDivElement | null} metadataElement
  * @returns {object} JSON
  */
 export function parseSectionMetadata(metadataElement) {
   const metadata = {};
-  [...metadataElement.children].forEach((child) => {
-    const key = toCamelCase(child.firstElementChild.textContent.trim());
-    const value = child.lastElementChild.textContent.trim();
-    metadata[key] = value;
-  });
 
-  metadataElement.remove();
+  if (metadataElement) {
+    [...metadataElement.children].forEach((child) => {
+      const key = toCamelCase(child.firstElementChild.textContent.trim());
+      const value = child.lastElementChild.textContent.trim();
+      metadata[key] = value;
+    });
+
+    metadataElement.remove();
+  }
 
   return metadata;
 }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #123

Test URLs:
- Before: https://main--helix-sportsmagazine--headwirecom.hlx.page/content-v2/the-loop/gambling/article/2023/7/british-open-picks-2023
- After: https://fix-123--helix-sportsmagazine--headwirecom.hlx.page/content-v2/the-loop/gambling/article/2023/7/british-open-picks-2023
