### PR TITLE
added editors note, adjusted byline to more closely fit golf version

### DIFF
--- a/blocks/full-bleed/full-bleed.css
+++ b/blocks/full-bleed/full-bleed.css
@@ -98,6 +98,18 @@
   }
 }
 
+.full-bleed.block .editors-note-wrapper p {
+  font-size: 16px;
+  font-family: var(--font-gotham);
+  font-weight: 500;
+}
+
+@media (min-width: 769px) {
+  .full-bleed.block .editors-note-wrapper p {
+    font-size: 18px;
+  }
+}
+
 .full-bleed.block .article-body div > p {
   margin: 0 auto 30px;
   font-size: 16px;
@@ -140,10 +152,19 @@
   margin: 0 10px;
 }
 
+.full-bleed.block .editors-note-wrapper {
+  padding: 0 20px;
+  max-width: 950px;
+  margin: 0 auto;
+}
+
 .full-bleed.block .byline {
   display: flex;
   height: 10px;
-  justify-content: space-around;
+  justify-content: space-between;
+  padding: 0 20px;
+  max-width: 950px;
+  margin: 0 auto;
 }
 
 @media (max-width: 768px) {
@@ -290,6 +311,10 @@
 .full-bleed.block .article-body a {
   color: #000;
   font-weight: 600;
+}
+
+.full-bleed.block .editors-note-wrapper p a {
+  color: #00e;
 }
 
 .full-bleed.block .attribution a:hover {

--- a/blocks/full-bleed/full-bleed.js
+++ b/blocks/full-bleed/full-bleed.js
@@ -26,6 +26,20 @@ export default async function decorate(block) {
   // TODO remove once importer fixes photo credit
   const photoCredit = headlineMetadata?.imageCredit ?? headlineMetadata?.photoCredit;
 
+  let editorsNoteString = getMetadata('editors_note');
+  if (editorsNoteString) {
+    const markdownLinksRegex = /\[([\w\s\d]+)\]\(((?:\/|https?:\/\/)[\w\d./?=#]+)\)/gm;
+    const linkMatches = editorsNoteString.match(markdownLinksRegex);
+
+    for (let i = 0; i < linkMatches.length; i += 1) {
+      const trimmedLink = linkMatches[i].substring(1, linkMatches[i].length - 1);
+
+      const [text, url] = trimmedLink.split('](');
+
+      editorsNoteString = editorsNoteString.replace(linkMatches[i], `<a class="editors-note-link" href="${url}">${text}</a>`);
+    }
+  }
+
   // HTML template in JS to avoid extra waterfall for LCP blocks
   const HTML_TEMPLATE = `
 <div class="container">
@@ -59,6 +73,7 @@ export default async function decorate(block) {
   <div class="container-article">
     <div class="content-wrapper">
         <article class="article-content">
+        ${editorsNoteString ? `<div class="editors-note-wrapper"><p><i>Editor's note: ${editorsNoteString}</i></p></div>` : ''}
             <div class="byline">
                 <div class="attribution">
                     <span>By</span>


### PR DESCRIPTION
added editors note metadata property, markdown style links will be used to create `<a>` tags
![image](https://github.com/headwirecom/helix-sportsmagazine/assets/68734204/42d00727-44a1-4b55-9bb1-0cf5f96e5158)


Fix #118 

Test URLs:
- Before: https://main--helix-sportsmagazine--headwirecom.hlx.page
- After: https://fullbleed-editors-note--helix-sportsmagazine--headwirecom.hlx.page
