### PR TITLE
inserting GDplus icons & banners into articles

### DIFF
--- a/blocks/default-article/default-article.css
+++ b/blocks/default-article/default-article.css
@@ -4,6 +4,12 @@
     padding: 20px;
 }
 
+.default-article.block .container .gd-plus-icon {
+    border-right: 2px solid #f6f6f6;
+    margin-right: 10px;
+    padding-right: 10px;
+}
+
 .default-article.block .container-article {
     display: flex;
     justify-content: space-between;

--- a/blocks/default-article/default-article.js
+++ b/blocks/default-article/default-article.js
@@ -5,6 +5,7 @@ import {
   normalizeAuthorURL,
   parseFragment,
   parseSectionMetadata,
+  premiumArticleBanner,
   removeEmptyElements,
   render,
   replaceLinksWithEmbed,
@@ -17,6 +18,7 @@ import {
  * @param {HTMLDivElement} block
  */
 export default async function decorate(block) {
+  const gdPlusArticle = getMetadata('gdplus').length > 0
   const rubric = getMetadata('rubric');
   const author = getMetadata('author');
   const publicationDate = getMetadata('publication-date');
@@ -29,7 +31,9 @@ export default async function decorate(block) {
     <div class="container">
       <div class="container-article">
         <article class="article-content">
+  ${!gdPlusArticle ? '' : premiumArticleBanner()}
           <p class="rubric">
+            ${!gdPlusArticle ? '' : '<img class="gd-plus-icon" width="51" height="19" src="/icons/gd-plus-dark.svg" alt="GD Plus Icon" />'}
             <span>${rubric}</span>
           </p>
           <div class="title">

--- a/blocks/full-bleed/full-bleed.css
+++ b/blocks/full-bleed/full-bleed.css
@@ -2,6 +2,30 @@
   margin: 0 auto;
 }
 
+.full-bleed.block .gd-plus-icon {
+  padding-right: 10px;
+  margin-right: 10px;
+  border-right: solid 2px white;
+  box-sizing: content-box;
+}
+.full-bleed.block .gd-plus-icon.dark {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .full-bleed.block .gd-plus-icon.dark {
+    display: block;
+  }
+
+  .full-bleed.block .gd-plus-icon.light {
+    display: none;
+  }
+
+  
+}
+
+
+
 .full-bleed.block .credit {
   margin: 0 auto;
   padding: 15px;
@@ -67,7 +91,8 @@
 .full-bleed.block .headline .rubric {
   font-size: 10px;
   margin-bottom: 20px;
-  display: block;
+  display: flex;
+  align-items: center;
   color: #adb4b7;
   font-weight: 500;
   letter-spacing: 0.3em;
@@ -272,7 +297,7 @@
   }
 }
 
-.full-bleed.block .lead img {
+.full-bleed.block .lead .image img {
   object-position: 50% 10%;
   height: auto;
   max-height: 680px;
@@ -281,7 +306,7 @@
 }
 
 @media (max-width: 768px) {
-  .full-bleed.block .lead img {
+  .full-bleed.block .lead .image img {
     height: auto;
     object-fit: cover;
   }

--- a/blocks/full-bleed/full-bleed.js
+++ b/blocks/full-bleed/full-bleed.js
@@ -6,6 +6,7 @@ import {
   parseSectionMetadata,
   addPhotoCredit,
   ARTICLE_TEMPLATES,
+  premiumArticleBanner,
 } from '../../scripts/scripts.js';
 import {
   buildBlock,
@@ -18,6 +19,8 @@ import {
  * @param {HTMLDivElement} block
  */
 export default async function decorate(block) {
+  const gdPlusArticle = getMetadata('gdplus').length > 0
+  
   const rubric = getMetadata('rubric');
   const author = getMetadata('author');
   const authorURL = getMetadata('author-url');
@@ -28,10 +31,15 @@ export default async function decorate(block) {
 
   // HTML template in JS to avoid extra waterfall for LCP blocks
   const HTML_TEMPLATE = `
+${!gdPlusArticle ? '' : premiumArticleBanner(2)}
 <div class="container">
   <div class="lead">
       <div class="headline">
           <p class="rubric">
+              ${!gdPlusArticle ? '' : `
+                <img width="51" height="19" class="gd-plus-icon light" src="/icons/gd-plus-light.svg" alt="GD Plus Icon" />
+                <img width="51" height="19" class="gd-plus-icon dark" src="/icons/gd-plus-dark.svg" alt="GD Plus Icon" />
+              `}
               <span>${rubric}</span>
           </p>
           <div class="title">

--- a/blocks/gallery/gallery.css
+++ b/blocks/gallery/gallery.css
@@ -20,7 +20,7 @@
   background-color: #f2f2f2;
 }
 
-.gallery.block .container-article img {
+.gallery.block .container-article img:not(.gd-plus-icon) {
   width: 100%;
   height: auto;
   object-fit: contain;

--- a/blocks/gallery/gallery.js
+++ b/blocks/gallery/gallery.js
@@ -2,12 +2,14 @@ import {
   normalizeAuthorURL,
   parseFragment,
   parseSectionMetadata,
+  premiumArticleBanner,
   render,
 } from '../../scripts/scripts.js';
 import {
   buildBlock, decorateBlock, getMetadata, loadBlocks,
 } from '../../scripts/lib-franklin.js';
 
+const gdPlusArticle = getMetadata('gdplus').length > 0
 const rubric = getMetadata('rubric');
 const author = getMetadata('author');
 // TODO remove once importer fixes photo credit
@@ -19,12 +21,14 @@ const HTML_TEMPLATE = `
 <div class="container">
   <div class="container-article">
     <article class="article-content">
-      ${rubric ? `<p class="rubric">
-        <span>${rubric}</span>
-      </p>` : ''}
+      ${!gdPlusArticle ? '' : premiumArticleBanner()}
       <div class="headline">
         <slot name="headline"></slot>
       </div>
+      <p class="rubric">
+        ${!gdPlusArticle ? '' : '<img class="gd-plus-icon" width="51" height="19" src="/icons/gd-plus-dark.svg" alt="GD Plus Icon" />'}
+        <span>${rubric}</span>
+      </p>
       <div class="byline${author || photoCredit ? '' : ' no-author'}">
         <div class="attribution">
           ${author ? `<span>By&nbsp;</span><a href="${normalizeAuthorURL(author)}">${author}</a>` : ''}

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -616,3 +616,31 @@ window.store = new (class {
       });
   }
 })();
+
+/**
+ * Generates HTML for the premium article banner.
+ * @param {Number} Number of leftover articles to compare to.
+ */
+export const premiumArticleBanner = (leftoverArticles=0) => {
+  let text;
+  if (leftoverArticles > 1) {
+    text = `You have <strong>${leftoverArticles}</strong> free premium articles remaining.`
+  }
+  if (leftoverArticles === 1) {
+    text = 'This is your last free premium article for the month.'
+  }
+  if (leftoverArticles < 1) {
+    text = 'You are out of free premium articles.'
+  }
+
+  return `
+    <div class="premium-article-banner ${leftoverArticles < 1 ? 'out-of-free-articles' : ''}">
+      <div class="premium-banner-text-wrapper">
+        <span class="premium-message">${text}</span>
+        <a class="premium-link" src="#" target="_blank">
+          Subscribe to <strong>Golf Digest<span class="red-plus">+</span></strong>
+        </a>
+      </div>
+    </div>
+  `
+};

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -153,3 +153,39 @@ a:hover {
 .landing-page main > div > * {
   margin-bottom: 40px;
 }
+
+/* premium banner */
+.premium-article-banner {
+  border-bottom: 3px solid #ff4140;
+  padding: 21px;
+  background-color: #f2f2f2;
+}
+
+.premium-article-banner.out-of-free-articles {
+  border: 2px solid #ff4140;
+}
+
+.premium-article-banner .premium-banner-text-wrapper {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  font-size: 16px;
+  font-family: var(--font-gotham);
+}
+
+.premium-article-banner .premium-link {
+  cursor: pointer;
+  text-decoration: underline;
+  transition: color .1s ease-out;
+  font-size: 16px;
+}
+
+.premium-article-banner .premium-link:hover {
+  color: #3577b1;
+}
+
+.premium-article-banner .premium-link .red-plus {
+  color: #ED3E49;
+}


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #120 

Test URLs:
- Before: https://main--helix-sportsmagazine--headwirecom.hlx.page/content-v2/golf-news-tours/_default/article/2023/4/how-course-designer-beau-welling-balances-a-life-of-golf-and-curling-the-fringe
- After: https://gdplus-variation-support--helix-sportsmagazine--headwirecom.hlx.page/content-v2/golf-news-tours/_default/article/2023/4/how-course-designer-beau-welling-balances-a-life-of-golf-and-curling-the-fringe

- Before: https://main--helix-sportsmagazine--headwirecom.hlx.page/content-v2/golf-news-tours/_default/article/2023/6/open-championship-2023-ra-chairman-defends-proper-name-golfs-oldest-major
- After: https://gdplus-variation-support--helix-sportsmagazine--headwirecom.hlx.page/content-v2/golf-news-tours/_default/article/2023/6/open-championship-2023-ra-chairman-defends-proper-name-golfs-oldest-major


- Before: https://main--helix-sportsmagazine--headwirecom.hlx.page/content-v2/magazine/_default/gallery/2019/12/the-arnie-award-golfers-who-give-back
- After: https://gdplus-variation-support--helix-sportsmagazine--headwirecom.hlx.page/content-v2/magazine/_default/gallery/2019/12/the-arnie-award-golfers-who-give-back


GD+ articles are defined by writing it in the metadata block with **any** string in the value field 
![image](https://github.com/headwirecom/helix-sportsmagazine/assets/68734204/e04b172d-670b-43c5-9622-e90a98a2c0bf)

