### PR TITLE
increased image source width to fix blurry images

### DIFF
--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -65,7 +65,12 @@ export default async function decorate(block) {
       return `
       <a class="main-card" href="${card.href || card.path}">
         <div class="image-bg">
-          ${createOptimizedPicture(card.image, card.imageAlt || card.title, false, [{ width: '700' }]).outerHTML}
+          ${createOptimizedPicture(card.image, card.imageAlt || card.title, false, [
+            { media: '(max-width: 768px)', width: '1440' },
+            { media: '(max-width: 1024px)', width: '1960' },
+            { media: '(max-width: 1280px)', width: '2460' },
+            { width: '1400' },
+          ]).outerHTML}
         </div>
         <div class="main-text-wrapper">
           <div class="section">${card.rubric}</div>
@@ -87,7 +92,10 @@ export default async function decorate(block) {
         (card) => `
         <a class="small-card" href="${card.href || card.path}">
           <div class="image-wrapper">
-            ${createOptimizedPicture(card.image, card.imageAlt || card.title, false, [{ width: '350' }]).outerHTML}
+            ${createOptimizedPicture(card.image, card.imageAlt || card.title, false, [
+              { media: '(max-width: 768px)', width: '430' },
+              { width: '650' },
+            ]).outerHTML}
           </div>
           <div class="small-text-wrapper">
             <div class="section">${card.rubric}</div>

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -66,11 +66,11 @@ export default async function decorate(block) {
       <a class="main-card" href="${card.href || card.path}">
         <div class="image-bg">
           ${createOptimizedPicture(card.image, card.imageAlt || card.title, false, [
-            { media: '(max-width: 768px)', width: '1440' },
-            { media: '(max-width: 1024px)', width: '1960' },
-            { media: '(max-width: 1280px)', width: '2460' },
-            { width: '1400' },
-          ]).outerHTML}
+    { media: '(max-width: 768px)', width: '1440' },
+    { media: '(max-width: 1024px)', width: '1960' },
+    { media: '(max-width: 1280px)', width: '2460' },
+    { width: '1400' },
+  ]).outerHTML}
         </div>
         <div class="main-text-wrapper">
           <div class="section">${card.rubric}</div>
@@ -93,9 +93,9 @@ export default async function decorate(block) {
         <a class="small-card" href="${card.href || card.path}">
           <div class="image-wrapper">
             ${createOptimizedPicture(card.image, card.imageAlt || card.title, false, [
-              { media: '(max-width: 768px)', width: '430' },
-              { width: '650' },
-            ]).outerHTML}
+    { media: '(max-width: 768px)', width: '430' },
+    { width: '650' },
+  ]).outerHTML}
           </div>
           <div class="small-text-wrapper">
             <div class="section">${card.rubric}</div>

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -59,7 +59,17 @@ export default async function decorate(block) {
           <a class="carousel-item" href="${carouselItem.path}" >
             <div class="carousel-item-wrapper">
               <div class="carousel-image-wrapper">
-                ${createOptimizedPicture(carouselItem.image, carouselItem.imageAlt || carouselItem.title, false, isLarge ? [{ width: '700' }] : [{ width: '500' }]).outerHTML}
+                ${createOptimizedPicture(carouselItem.image, carouselItem.imageAlt || carouselItem.title, false, isLarge ? [
+                  {media: '(max-width: 768px)', width: '1300'},
+                  {media: '(max-width: 1024px)', width: '1000'},
+                  {media: '(max-width: 1280px)', width: '1200'},
+                  { width: '1400' }
+                ] : [
+                  {media: '(max-width: 768px)', width: '660'},
+                  {media: '(max-width: 1024px)', width: '1000'},
+                  {media: '(max-width: 1280px)', width: '560'},
+                  { width: '650' }
+                ]).outerHTML}
               </div>
               
               <div class="carousel-text-content">

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -60,16 +60,16 @@ export default async function decorate(block) {
             <div class="carousel-item-wrapper">
               <div class="carousel-image-wrapper">
                 ${createOptimizedPicture(carouselItem.image, carouselItem.imageAlt || carouselItem.title, false, isLarge ? [
-                  {media: '(max-width: 768px)', width: '1300'},
-                  {media: '(max-width: 1024px)', width: '1000'},
-                  {media: '(max-width: 1280px)', width: '1200'},
-                  { width: '1400' }
-                ] : [
-                  {media: '(max-width: 768px)', width: '660'},
-                  {media: '(max-width: 1024px)', width: '1000'},
-                  {media: '(max-width: 1280px)', width: '560'},
-                  { width: '650' }
-                ]).outerHTML}
+    { media: '(max-width: 768px)', width: '1300' },
+    { media: '(max-width: 1024px)', width: '1000' },
+    { media: '(max-width: 1280px)', width: '1200' },
+    { width: '1400' },
+  ] : [
+    { media: '(max-width: 768px)', width: '660' },
+    { media: '(max-width: 1024px)', width: '1000' },
+    { media: '(max-width: 1280px)', width: '560' },
+    { width: '650' },
+  ]).outerHTML}
               </div>
               
               <div class="carousel-text-content">

--- a/blocks/gdplus-subscribe-hero/gdplus-subscribe-hero.js
+++ b/blocks/gdplus-subscribe-hero/gdplus-subscribe-hero.js
@@ -15,9 +15,9 @@ export default async function decorate(block) {
       <div class="image-overlay"></div>
       ${
   createOptimizedPicture('/subscribe-background-mockup.jpg', 'hero background green', true, [
-    { media: '(max-width: 768px)', width: '1135' },
-    { media: '(max-width: 1297px)', width: '1280' },
-    { width: '1690' },
+    { media: '(max-width: 768px)', width: '2270' },
+    { media: '(max-width: 1297px)', width: '2560' },
+    { width: '3380' },
   ]).outerHTML
 }
       </div>
@@ -75,9 +75,9 @@ export default async function decorate(block) {
   <div class="gd-plus-benefits-content">
     ${
   createOptimizedPicture('/subscribe-device-mockup.png', 'Golf Digest Plus Promo Image', false, [
-    { media: '(max-width: 768px)', width: '707' },
-    { media: '(max-width: 1297px)', width: '1236' },
-    { width: '714' },
+    { media: '(max-width: 768px)', width: '1414' },
+    { media: '(max-width: 1297px)', width: '2472' },
+    { width: '1428' },
   ]).outerHTML
 }
     <ul class="benefits-list">

--- a/blocks/hero/hero.js
+++ b/blocks/hero/hero.js
@@ -47,7 +47,7 @@ export default async function decorate(block) {
           (card) => `
               <a href='${card.path}'>
                 ${
-  createOptimizedPicture(card.image, card.imageAlt || card.title, isFirstHero, [{ width: '120' }])
+  createOptimizedPicture(card.image, card.imageAlt || card.title, isFirstHero, [{ width: '240' }])
     .outerHTML
 }
                 <div>
@@ -78,10 +78,11 @@ export default async function decorate(block) {
     heroData.imageAlt || heroData.title,
     isFirstHero,
     [
-      { media: '(min-width: 686px)', width: '686' },
-      { media: '(min-width: 966px)', width: '966' },
-      { media: '(min-width: 1280px)', width: '1280' },
-      { width: '1850' },
+      { media: '(min-width: 686px)', width: '1500' },
+      { media: '(min-width: 768px)', width: '2000' },
+      { media: '(min-width: 1024px)', width: '1280' },
+      { media: '(min-width: 1280px)', width: '2500' },
+      { width: '3000' },
     ],
   ).outerHTML
 }

--- a/blocks/loop/loop.js
+++ b/blocks/loop/loop.js
@@ -30,9 +30,9 @@ const placeholderLoopCardHtml = ({
       <a class="loop-card" href="${path}"> 
         <div class="image-wrapper">
           ${image ? createOptimizedPicture(image, imageAlt, index <= numberOfEagerCards, [
-    { media: '(max-width: 768px)', width: !isEven ? '710' : '591' },
-    { media: '(max-width: 1024px)', width: !isEven ? '474' : '254' },
-    { width: !isEven ? '345' : '225' },
+    { media: '(max-width: 768px)', width: !isEven ? '1180' : '1420' },
+    { media: '(max-width: 1024px)', width: !isEven ? '950' : '700' },
+    { width: !isEven ? '690' : '450' },
   ]).outerHTML : '<picture></picture>'}
         </div>
         <div class="text-wrapper">
@@ -56,8 +56,8 @@ const placeholderTrendingItemHtml = ({
     <a class="trending-link" href="${path}">
       <div class="trending-image-wrapper">
         ${image ? createOptimizedPicture(image, imageAlt, true, [
-    { media: '(max-width: 768px)', width: '180' },
-    { width: '220' },
+    { media: '(max-width: 768px)', width: '360' },
+    { width: '440' },
   ]).outerHTML : '<picture></picture>'}
       </div>
       <div class="trending-text-wrapper">

--- a/blocks/newsletter-subscribe/newsletter-subscribe.js
+++ b/blocks/newsletter-subscribe/newsletter-subscribe.js
@@ -101,8 +101,8 @@ export default async function decorate(block) {
   <div class="image-wrapper">
     ${
   createOptimizedPicture(image, imageAlt, index < 2, [
-    { media: '(max-width: 600px)', width: '115' },
-    { width: '285' },
+    { media: '(max-width: 600px)', width: '230' },
+    { width: '570' },
   ]).outerHTML
 }
   </div>

--- a/blocks/series-cards/series-cards.js
+++ b/blocks/series-cards/series-cards.js
@@ -17,9 +17,9 @@ const placeholderSeriesCard = ({
       ${
   image
     ? createOptimizedPicture(image, imageAlt || title, index < 4, [
-      { media: '(max-width: 768px)', width: '132' },
-      { media: '(max-width: 1024px)', width: '276' },
-      { width: '256' },
+      { media: '(max-width: 768px)', width: '264' },
+      { media: '(max-width: 1024px)', width: '980' },
+      { width: '910' },
     ]).outerHTML
     : '<picture></picture>'
 }

--- a/blocks/tiger-cards/tiger-cards.js
+++ b/blocks/tiger-cards/tiger-cards.js
@@ -23,9 +23,9 @@ const placeholderSeriesCard = ({
       ${
   image
     ? createOptimizedPicture(image, imageAlt || title, false, [
-      { media: '(max-width: 768px)', width: '150' },
-      { media: '(max-width: 1024px)', width: '256' },
-      { width: '356' },
+      { media: '(max-width: 768px)', width: '300' },
+      { media: '(max-width: 1024px)', width: '460' },
+      { width: '712' },
     ]).outerHTML
     : '<picture></picture>'
 }


### PR DESCRIPTION
Changed breakpoint sizes of images to be double the rendered width.
Before it was sometimes set to the rendered width, and sometimes the intrinsic width.

partially fixes:
#103 
Higher quality images still need to be imported in order for there to be a difference in heros etc.
Once higher quality images exist, page-speed should be checked as this could cause issues.

Test URLs:
- Before: https://main--helix-sportsmagazine--headwirecom.hlx.page
- After: https://blurry-image-fix--helix-sportsmagazine--headwirecom.hlx.page

- Before: https://main--helix-sportsmagazine--headwirecom.hlx.page/newsletter/subscribe
- After: https://blurry-image-fix--helix-sportsmagazine--headwirecom.hlx.page/newsletter/subscribe


- Before: https://main--helix-sportsmagazine--headwirecom.hlx.page/the-loop
- After: https://blurry-image-fix--helix-sportsmagazine--headwirecom.hlx.page/the-loop


- Before: https://main--helix-sportsmagazine--headwirecom.hlx.page/video/all-series
- After: https://blurry-image-fix--helix-sportsmagazine--headwirecom.hlx.page/video/all-series


- Before: https://main--helix-sportsmagazine--headwirecom.hlx.page/video/the-tiger-hub
- After: https://blurry-image-fix--helix-sportsmagazine--headwirecom.hlx.page/video/the-tiger-hub


- Before: https://main--helix-sportsmagazine--headwirecom.hlx.page/subscribe-golf-digest-plus
- After: https://blurry-image-fix--helix-sportsmagazine--headwirecom.hlx.page/subscribe-golf-digest-plus

