### PR TITLE
added block-wrapper selector to css selectors

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -338,9 +338,7 @@
     font-size: 24px;
   }
 
-  .landing-page
-    main
-    .cards-wrapper
+  .cards-wrapper
     .cards.block.columns
     .card-block-wrapper
     .secondary-cards
@@ -371,9 +369,7 @@
     min-height: 132px;
   }
 
-  .landing-page
-    main
-    .cards-wrapper
+  .cards-wrapper
     .cards.block.latest
     .card-block-wrapper
     .secondary-cards
@@ -422,9 +418,7 @@
     flex: none;
   }
 
-  .landing-page
-    main
-    .cards-wrapper
+  .cards-wrapper
     .cards.block
     .card-block-wrapper
     .secondary-cards
@@ -475,9 +469,7 @@
     aspect-ratio: 16/9;
   }
 
-  .landing-page
-    main
-    .cards-wrapper
+  .cards-wrapper
     .cards.block.latest
     .card-block-wrapper
     .secondary-cards
@@ -493,9 +485,7 @@
     display: flex;
   }
 
-  .landing-page
-    main
-    .cards-wrapper
+  .cards-wrapper
     .cards.block.columns
     .card-block-wrapper
     .secondary-cards

--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -1,4 +1,4 @@
-.carousel.block {
+.carousel-wrapper .carousel.block {
   width: 100%;
   display: flex;
   flex-direction: column;
@@ -8,13 +8,13 @@
   --carousel-card-gap: 28px;
 }
 
-.carousel.block.large {
+.carousel-wrapper .carousel.block.large {
   --carousel-card-gap: 12px;
 
   position: relative;
 }
 
-.carousel.block.wedges {
+.carousel-wrapper .carousel.block.wedges {
   width: 100%;
   margin: 100px 0;
   background-color: #0b3b40;
@@ -23,7 +23,7 @@
   --carousel-card-gap: 40px;
 }
 
-.carousel.block picture {
+.carousel-wrapper .carousel.block picture {
   width: 100%;
   height: 100%;
   position: absolute;
@@ -32,19 +32,19 @@
 }
 
 @media (max-width: 1280px) {
-  .carousel.block.wedges {
+  .carousel-wrapper .carousel.block.wedges {
     --carousel-card-gap: 11px;
   }
 }
 
-.carousel-title-wrapper {
+.carousel-wrapper .carousel.block .carousel-title-wrapper {
   display: flex;
   width: 100%;
   max-width: 1440px;
   padding: 15px;
 }
 
-.carousel-title-wrapper .carousel-title {
+.carousel-wrapper .carousel.block .carousel-title-wrapper .carousel-title {
   margin: 0;
   font-family: var(--font-tungsten);
   text-transform: uppercase;
@@ -55,7 +55,7 @@
   align-items: center;
 }
 
-.carousel-title-wrapper .carousel-title::before {
+.carousel-wrapper .carousel.block .carousel-title-wrapper .carousel-title::before {
   content: "";
   display: block;
   width: 5px;
@@ -64,32 +64,32 @@
   background-color: #ed3e49;
 }
 
-.carousel-title-wrapper .carousel-title.courses::before {
+.carousel-wrapper .carousel.block .carousel-title-wrapper .carousel-title.courses::before {
   background-color: #105259;
 }
 
-.carousel-title-wrapper .carousel-title.loop::before {
+.carousel-wrapper .carousel.block .carousel-title-wrapper .carousel-title.loop::before {
   background-color: #e8b94d;
 }
 
-.carousel-title-wrapper:has(.carousel-title.wedges) {
+.carousel-wrapper .carousel.block .carousel-title-wrapper:has(.carousel-title.wedges) {
   margin-top: 45px;
   margin-bottom: 34px;
   justify-content: center;
 }
 
-.carousel-title-wrapper .carousel-title.wedges {
+.carousel-wrapper .carousel.block .carousel-title-wrapper .carousel-title.wedges {
   font-size: 67px;
   font-weight: 600;
   color: white;
   margin-bottom: 15px;
 }
 
-.carousel-title-wrapper .carousel-title.wedges::before {
+.carousel-wrapper .carousel.block .carousel-title-wrapper .carousel-title.wedges::before {
   display: none;
 }
 
-.carousel.block .carousel-main-wrapper {
+.carousel-wrapper .carousel.block .carousel-main-wrapper {
   padding: 0 15px;
   margin-bottom: 40px;
   height: 395px;
@@ -100,42 +100,42 @@
 }
 
 @media (max-width: 1024px) {
-  .carousel.block.wedges {
+  .carousel-wrapper .carousel.block.wedges {
     margin: 100px 0 40px;
   }
 
-  .carousel.block .carousel-main-wrapper {
+  .carousel-wrapper .carousel.block .carousel-main-wrapper {
     height: auto;
   }
 }
 
-.carousel.block.wedges .carousel-main-wrapper {
+.carousel-wrapper .carousel.block.wedges .carousel-main-wrapper {
   max-width: 1630px;
   padding: 0;
   margin-bottom: 55px;
   height: auto;
 }
 
-.carousel.block .carousel-main-wrapper .carousel-inner-wrapper {
+.carousel-wrapper .carousel.block .carousel-main-wrapper .carousel-inner-wrapper {
   height: 100%;
   width: 100%;
 }
 
-.carousel.block.large .carousel-main-wrapper .carousel-inner-wrapper {
+.carousel-wrapper .carousel.block.large .carousel-main-wrapper .carousel-inner-wrapper {
   height: 100%;
   width: 100%;
 }
 
-.carousel.block.wedges .carousel-main-wrapper .carousel-inner-wrapper {
+.carousel-wrapper .carousel.block.wedges .carousel-main-wrapper .carousel-inner-wrapper {
   overflow: hidden;
 }
 
-.carousel.block.wedges .carousel-main-wrapper.mobile-wedges {
+.carousel-wrapper .carousel.block.wedges .carousel-main-wrapper.mobile-wedges {
   overflow: visible;
   width: 100%;
 }
 
-.carousel.block .controls {
+.carousel-wrapper .carousel.block .controls {
   position: absolute;
   width: 100%;
   height: 100%;
@@ -144,17 +144,17 @@
   justify-content: space-between;
 }
 
-.carousel.block.wedges .controls {
+.carousel-wrapper .carousel.block.wedges .controls {
   max-width: 1630px;
 }
 
 @media (max-width: 779px) {
-  .carousel.block .controls {
+  .carousel-wrapper .carousel.block .controls {
     display: none;
   }
 }
 
-.carousel.block .controls button {
+.carousel-wrapper .carousel.block .controls button {
   border: none;
   background-color: #151517;
   background-image: url("/icons/carousel-next-arrow.svg");
@@ -170,37 +170,37 @@
   top: 96px;
 }
 
-.carousel.block.wedges .controls button {
+.carousel-wrapper .carousel.block.wedges .controls button {
   top: 170px;
 }
 
-.carousel.block.large .controls button {
+.carousel-wrapper .carousel.block.large .controls button {
   top: calc(50% - 40px);
 }
 
-.carousel.block .controls button.hidden {
+.carousel-wrapper .carousel.block .controls button.hidden {
   visibility: hidden;
 }
 
-.carousel.block .controls button.right-button {
+.carousel-wrapper .carousel.block .controls button.right-button {
   left: auto;
   right: 26px;
 }
 
-.carousel.block.large .controls button.right-button {
+.carousel-wrapper .carousel.block.large .controls button.right-button {
   right: 16px;
 }
 
-.carousel.block.wedges .controls button.right-button {
+.carousel-wrapper .carousel.block.wedges .controls button.right-button {
   right: -10px;
 }
 
 
-.carousel.block .controls button.left-button {
+.carousel-wrapper .carousel.block .controls button.left-button {
   transform: rotate(180deg);
 }
 
-.carousel.block .carousel-main-wrapper .carousel-frame {
+.carousel-wrapper .carousel.block .carousel-main-wrapper .carousel-frame {
   display: flex;
   gap: var(--carousel-card-gap);
   height: 100%;
@@ -208,18 +208,18 @@
   transition: all 0.25s ease 0s;
 }
 
-.carousel.block .carousel-main-wrapper.grabbed .carousel-frame {
+.carousel-wrapper .carousel.block .carousel-main-wrapper.grabbed .carousel-frame {
   transition: none;
 }
 
-.carousel.block.wedges .carousel-main-wrapper.mobile-wedges .carousel-frame {
+.carousel-wrapper .carousel.block.wedges .carousel-main-wrapper.mobile-wedges .carousel-frame {
   display: grid;
   grid-template-columns: repeat(6, 1fr);
   flex-wrap: wrap;
   width: 100%;
 }
 
-.carousel.block .carousel-main-wrapper .carousel-frame .carousel-item {
+.carousel-wrapper .carousel.block .carousel-main-wrapper .carousel-frame .carousel-item {
   width: calc(25% - var(--carousel-card-gap) + 4px);
   display: flex;
   flex-direction: column;
@@ -229,7 +229,7 @@
   flex-shrink: 0;
 }
 
-.dark .carousel.block
+.dark .carousel-wrapper .carousel.block
   .carousel-main-wrapper
   .carousel-frame
   .carousel-item {
@@ -237,7 +237,7 @@
  border: none;
 }
 
-.carousel.block.wedges .carousel-main-wrapper .carousel-frame .carousel-item {
+.carousel-wrapper .carousel.block.wedges .carousel-main-wrapper .carousel-frame .carousel-item {
   background: none;
   border: none;
   width: calc(16.66% - var(--carousel-card-gap) + 6px);
@@ -245,61 +245,61 @@
   height: auto;
 }
 
-.carousel.block.large .carousel-main-wrapper {
+.carousel-wrapper .carousel.block.large .carousel-main-wrapper {
   height: auto;
 }
 
-.carousel.block.large .carousel-main-wrapper .carousel-frame .carousel-item {
+.carousel-wrapper .carousel.block.large .carousel-main-wrapper .carousel-frame .carousel-item {
   width: calc(50% - var(--carousel-card-gap) + 7px);
   aspect-ratio: 1/1;
   height: auto;
   position: relative;
 }
 
-.carousel.block.wedges .carousel-main-wrapper.mobile-wedges .carousel-frame .carousel-item {
+.carousel-wrapper .carousel.block.wedges .carousel-main-wrapper.mobile-wedges .carousel-frame .carousel-item {
   width: 100%;
 }
 
 @media (max-width: 1280px) {
-  .carousel.block.wedges .carousel-main-wrapper .carousel-frame .carousel-item {
+  .carousel-wrapper .carousel.block.wedges .carousel-main-wrapper .carousel-frame .carousel-item {
     width: calc(33.33% - var(--carousel-card-gap) + 6px);
   }
 
-  .carousel.block.wedges .carousel-main-wrapper.mobile-wedges .carousel-frame {
+  .carousel-wrapper .carousel.block.wedges .carousel-main-wrapper.mobile-wedges .carousel-frame {
     grid-template-columns: repeat(3, 1fr);
   }
 
-  .carousel.block.wedges .carousel-main-wrapper.mobile-wedges .carousel-frame .carousel-item {
+  .carousel-wrapper .carousel.block.wedges .carousel-main-wrapper.mobile-wedges .carousel-frame .carousel-item {
     width: 100%;
   }
 }
 
 @media (max-width: 779px) {
-  .carousel.block.wedges .carousel-main-wrapper {
+  .carousel-wrapper .carousel.block.wedges .carousel-main-wrapper {
     padding: 0;
   }
 
-  .carousel.block.wedges .carousel-main-wrapper.mobile-wedges .carousel-frame {
+  .carousel-wrapper .carousel.block.wedges .carousel-main-wrapper.mobile-wedges .carousel-frame {
     grid-template-columns: repeat(2, 1fr);
   }
 
-  .carousel.block.wedges .carousel-main-wrapper.mobile-wedges .carousel-frame .carousel-item {
+  .carousel-wrapper .carousel.block.wedges .carousel-main-wrapper.mobile-wedges .carousel-frame .carousel-item {
     width: 100%;
   }
 }
 
-.carousel.block.wedges .carousel-main-wrapper .carousel-frame .carousel-item div.carousel-image-wrapper {
+.carousel-wrapper .carousel.block.wedges .carousel-main-wrapper .carousel-frame .carousel-item div.carousel-image-wrapper {
   aspect-ratio: 1/1;
   margin: 0 0 21px;
 }
 
-.carousel.block.large .carousel-main-wrapper .carousel-frame .carousel-item div.carousel-image-wrapper {
+.carousel-wrapper .carousel.block.large .carousel-main-wrapper .carousel-frame .carousel-item div.carousel-image-wrapper {
   width: 100%;
   height: 100%;
   position: absolute;
 }
 
-.carousel.block.wedges
+.carousel-wrapper .carousel.block.wedges
   .carousel-main-wrapper
   .carousel-frame
   .carousel-item
@@ -309,7 +309,7 @@
   object-position: 0% 0%;
 }
 
-.carousel.block.wedges .carousel-main-wrapper .carousel-frame .carousel-item .carousel-image-wrapper picture::before {
+.carousel-wrapper .carousel.block.wedges .carousel-main-wrapper .carousel-frame .carousel-item .carousel-image-wrapper picture::before {
   content: "";
   display: block;
   position: absolute;
@@ -317,7 +317,7 @@
   width: 100%;
 }
 
-.carousel.block.wedges .carousel-main-wrapper .carousel-frame .carousel-item .carousel-image-wrapper picture::after {
+.carousel-wrapper .carousel.block.wedges .carousel-main-wrapper .carousel-frame .carousel-item .carousel-image-wrapper picture::after {
   top: 35%;
   pointer-events: all;
   content: "";
@@ -329,29 +329,29 @@
 }
 
 @media (max-width: 1024px) {
-  .carousel.block .carousel-main-wrapper .carousel-frame {
+  .carousel-wrapper .carousel.block .carousel-main-wrapper .carousel-frame {
     height: auto;
   }
 
-  .carousel.block .carousel-main-wrapper .carousel-frame .carousel-item {
+  .carousel-wrapper .carousel.block .carousel-main-wrapper .carousel-frame .carousel-item {
     width: calc(50% - 24px);
   }
 }
 
-.carousel.block .carousel-main-wrapper .carousel-frame .carousel-item .carousel-item-wrapper {
+.carousel-wrapper .carousel.block .carousel-main-wrapper .carousel-frame .carousel-item .carousel-item-wrapper {
   width: 100%;
   height: 100%;
 }
 
 @media (max-width: 1024px) {
-  .carousel.block .carousel-main-wrapper .carousel-frame .carousel-item .carousel-item-wrapper {
+  .carousel-wrapper .carousel.block .carousel-main-wrapper .carousel-frame .carousel-item .carousel-item-wrapper {
     width: 100%;
     height: 100%;
     aspect-ratio: 1/1;
   }
 }
 
-.carousel.block .carousel-main-wrapper .carousel-frame .carousel-item .carousel-item-wrapper .carousel-image-wrapper {
+.carousel-wrapper .carousel.block .carousel-main-wrapper .carousel-frame .carousel-item .carousel-item-wrapper .carousel-image-wrapper {
   margin: -0.5px;
   width: calc(100% - 1px);
   height: auto;
@@ -360,7 +360,7 @@
   flex-shrink: 0;
 }
 
-.carousel.block
+.carousel-wrapper .carousel.block
   .carousel-main-wrapper
   .carousel-frame
   .carousel-item
@@ -372,7 +372,7 @@
   width: 100%;
 }
 
-.carousel.block
+.carousel-wrapper .carousel.block
   .carousel-main-wrapper
   .carousel-frame
   .carousel-item
@@ -392,7 +392,7 @@
   z-index: 1;
 }
 
-.carousel.block
+.carousel-wrapper .carousel.block
   .carousel-main-wrapper
   .carousel-frame
   .carousel-item:hover
@@ -402,14 +402,14 @@
   transform: scale(1.2);
 }
 
-.carousel.block .carousel-main-wrapper .carousel-frame .carousel-item .carousel-item-wrapper .carousel-text-content {
+.carousel-wrapper .carousel.block .carousel-main-wrapper .carousel-frame .carousel-item .carousel-item-wrapper .carousel-text-content {
   display: flex;
   flex-direction: column;
   padding: 20px;
   gap: 10px;
 }
 
-.carousel.large .carousel-main-wrapper .carousel-frame .carousel-item .carousel-item-wrapper .carousel-text-content {
+.carousel-wrapper .carousel.block.large .carousel-main-wrapper .carousel-frame .carousel-item .carousel-item-wrapper .carousel-text-content {
   background: linear-gradient(180deg, transparent 50%, #000);
   display: flex;
   position: relative;
@@ -422,7 +422,7 @@
   z-index: 1;
 }
 
-.carousel.block.wedges
+.carousel-wrapper .carousel.block.wedges
   .carousel-main-wrapper
   .carousel-frame
   .carousel-item
@@ -432,7 +432,7 @@
   padding: 0;
 }
 
-.carousel.block
+.carousel-wrapper .carousel.block
   .carousel-main-wrapper
   .carousel-frame
   .carousel-item
@@ -448,7 +448,7 @@
   font-family: var(--font-gotham);
 }
 
-.carousel.block.wedges
+.carousel-wrapper .carousel.block.wedges
   .carousel-main-wrapper
   .carousel-frame
   .carousel-item
@@ -459,11 +459,11 @@
 }
 
 @media (max-width: 779px) {
-  .carousel.block.large .carousel-main-wrapper .carousel-frame .carousel-item {
+  .carousel-wrapper .carousel.block.large .carousel-main-wrapper .carousel-frame .carousel-item {
     width: 90%;
   }
 
-  .carousel.block.large
+  .carousel-wrapper .carousel.block.large
     .carousel-main-wrapper
     .carousel-frame
     .carousel-item
@@ -472,7 +472,7 @@
     padding: 18px;
   }
 
-  .carousel.block.large
+  .carousel-wrapper .carousel.block.large
     .carousel-main-wrapper
     .carousel-frame
     .carousel-item
@@ -483,7 +483,7 @@
   }
 }
 
-.carousel.block
+.carousel-wrapper .carousel.block
   .carousel-main-wrapper
   .carousel-frame
   .carousel-item
@@ -499,7 +499,7 @@
   margin: 0;
 }
 
-.carousel.block.wedges
+.carousel-wrapper .carousel.block.wedges
   .carousel-main-wrapper
   .carousel-frame
   .carousel-item
@@ -517,7 +517,7 @@
   text-align: center;
 }
 
-.carousel.block.large
+.carousel-wrapper .carousel.block.large
   .carousel-main-wrapper
   .carousel-frame
   .carousel-item
@@ -535,7 +535,7 @@
   margin: 0;
 }
 
-.carousel.block
+.carousel-wrapper .carousel.block
   .carousel-main-wrapper
   .carousel-frame
   .carousel-item
@@ -549,7 +549,7 @@
   line-height: 130%;
 }
 
-.carousel.block.large
+.carousel-wrapper .carousel.block.large
   .carousel-main-wrapper
   .carousel-frame
   .carousel-item
@@ -559,7 +559,7 @@
   display: none;
 }
 
-.carousel.block.wedges
+.carousel-wrapper .carousel.block.wedges
   .carousel-main-wrapper
   .carousel-frame
   .carousel-item
@@ -569,7 +569,7 @@
   display: none;
 }
 
-.carousel.block
+.carousel-wrapper .carousel.block
   .carousel-main-wrapper
   .carousel-frame
   .carousel-item
@@ -585,7 +585,7 @@
   margin-top: 6px;
 }
 
-.carousel.block.wedges
+.carousel-wrapper .carousel.block.wedges
   .carousel-main-wrapper
   .carousel-frame
   .carousel-item
@@ -595,7 +595,7 @@
   display: none;
 }
 
-.carousel.block
+.carousel-wrapper .carousel.block
   .carousel-main-wrapper
   .carousel-frame
   .carousel-item
@@ -617,7 +617,7 @@
 }
 
 /* Carousel dark */
-.dark .carousel.block
+.dark .carousel-wrapper .carousel.block
   .carousel-main-wrapper
   .carousel-frame
   .carousel-item
@@ -628,12 +628,12 @@
 
 }
 
-.dark .carousel.block {
+.dark .carousel-wrapper .carousel.block {
   background-color: black;
   color: white;
 }
 
-.dark .carousel.block
+.dark .carousel-wrapper .carousel.block
   .carousel-main-wrapper
   .carousel-frame
   .carousel-item
@@ -646,12 +646,12 @@
 
 
 /* With video variation */
-.carousel.block.with-video
+.carousel-wrapper .carousel.block.with-video
   .carousel-main-wrapper {
     max-height: 330px;
 }
 
-.carousel.block.with-video
+.carousel-wrapper .carousel.block.with-video
   .carousel-main-wrapper
   .carousel-frame
   .carousel-item
@@ -660,7 +660,7 @@
   padding-top: 55%;
 }
 
-.carousel.block.with-video
+.carousel-wrapper .carousel.block.with-video
   .carousel-main-wrapper
   .carousel-frame
   .carousel-item
@@ -669,7 +669,7 @@
   padding: 20px;
 }
 
-.dark .carousel.block
+.dark .carousel-wrapper .carousel.block
   .carousel-main-wrapper
   .carousel-frame
   .carousel-item
@@ -692,7 +692,7 @@
 
 
 @media (max-width: 768px) {
-  .carousel.block.with-video .carousel-main-wrapper {
+  .carousel-wrapper .carousel.block.with-video .carousel-main-wrapper {
     max-height: 280px;
   }
 }

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -4,7 +4,7 @@
   color: white;
 }
 
-.columns.block {
+.columns-wrapper .columns.block {
   max-width: var(--layout-width);
   margin: auto;
   padding: 20px 0;
@@ -104,7 +104,7 @@
 }
 
 @media (max-width: 1281px) {
-  .columns.block {
+  .columns-wrapper .columns.block {
     padding: 0;
   }
 

--- a/blocks/courses/courses.css
+++ b/blocks/courses/courses.css
@@ -1,4 +1,4 @@
-.courses.block {
+.courses-wrapper .courses.block {
     border: 1px solid #e6e6e6;
     display: flex;
     flex-wrap: wrap;
@@ -8,65 +8,50 @@
     margin: 20px;
 }
 
-.courses.block .courses-info-wrapper {
+.courses-wrapper .courses.block .courses-info-wrapper {
     display: flex;
 }
 
-.courses.block .courses-info-wrapper + p {
+.courses-wrapper .courses.block .courses-info-wrapper + p {
     margin-bottom: 0;
 }
 
-.courses.block .courses-text-wrapper {
+.courses-wrapper .courses.block .courses-text-wrapper {
     margin-left: 20px;
 }
 
-.courses.block .courses-info-wrapper picture img:not(.gd-plus-icon) {
+.courses-wrapper .courses.block .courses-info-wrapper picture img:not(.gd-plus-icon) {
     width: 100%;
     height: 180px;
     object-fit: cover;
     object-position: center;
 }
 
-.courses.block p.courses-picture {
+.courses-wrapper .courses.block p.courses-picture {
     flex-basis: 40%; 
     max-width: 40%; 
     margin-right: 20px; 
 }
 
-.courses.block .courses-title  {
+.courses-wrapper .courses.block .courses-title  {
     text-decoration: none;
     color: #151517;
     font-size: 16px;
     margin: 10px 0;
 }
 
-.courses.block .courses-subtitle {
+.courses-wrapper .courses.block .courses-subtitle {
     font-weight: 100;
     margin:  10px 0;
 }
 
-.courses.block .courses-rating,
-.courses.block .courses-panelists {
+.courses-wrapper .courses.block .courses-rating,
+.courses-wrapper .courses.block .courses-panelists {
     display: inline-block;
     margin-right: 15px;
 }
 
-.courses.block .courses-title a {
-    text-decoration: none;
-    color: #151517;
-    font-size: 16px;
-}
-
-.courses.block .courses-info a {
-    text-decoration: none;
-}
-
-.courses.block .courses-button a {
-    text-decoration: none;
-}
-
-
-.article-body  .courses-text-wrapper .courses-tags > li > a {
+.article-body .courses-text-wrapper .courses-tags > li > a {
     text-decoration: none; 
     color: #fff;
     background: #105259;
@@ -90,6 +75,20 @@
     padding: 0;
 }
 
+.courses-wrapper .courses.block .courses-title a {
+    text-decoration: none;
+    color: #151517;
+    font-size: 16px;
+}
+
+.courses-wrapper .courses.block .courses-info a {
+    text-decoration: none;
+}
+
+.courses-wrapper .courses.block .courses-button a {
+    text-decoration: none;
+}
+
 .article-body > div .courses-photo-credit.photo-credit:first-of-type::first-letter {
     float: none;
     margin-right: 0;
@@ -106,33 +105,33 @@
     color: inherit; 
 }
 
-.article-body .courses.block .courses-photo-credit.photo-credit {
+.article-body .courses-wrapper .courses.block .courses-photo-credit.photo-credit {
     margin: 0;
 }
 
-.article-body .courses.block .courses-subtitle {
+.article-body .courses-wrapper .courses.block .courses-subtitle {
     margin-bottom: 15px;
 }
 
-.article-body .courses.block .courses-rating {
+.article-body .courses-wrapper .courses.block .courses-rating {
     margin-bottom: 15px;
 }
 
-.article-body .courses.block .photo-credit, 
-.article-body .courses.block .courses-title, 
-.article-body .courses.block .courses-panelists {
+.article-body .courses-wrapper .courses.block .photo-credit, 
+.article-body .courses-wrapper .courses.block .courses-title, 
+.article-body .courses-wrapper .courses.block .courses-panelists {
     margin-bottom: 5px;
 }
 
-.default-article.block .article-body .courses.block .photo-credit, 
-.default-article.block .article-body .courses.block .courses-title, 
-.default-article.block .article-body .courses.block .courses-subtitle,
-.default-article.block .article-body .courses.block .courses-rating, 
-.default-article.block .article-body .courses.block .courses-panelists {
+.default-article.block .article-body .courses-wrapper .courses.block .photo-credit, 
+.default-article.block .article-body .courses-wrapper .courses.block .courses-title, 
+.default-article.block .article-body .courses-wrapper .courses.block .courses-subtitle,
+.default-article.block .article-body .courses-wrapper .courses.block .courses-rating, 
+.default-article.block .article-body .courses-wrapper .courses.block .courses-panelists {
     margin-bottom: 5px;
 }
 
-.default-article.block .article-body .courses.block .photo-credit {
+.default-article.block .article-body .courses-wrapper .courses.block .photo-credit {
     text-transform: uppercase;
     margin-top: 1px;
     font-size: 10px;
@@ -148,7 +147,7 @@
     margin-top: -30px;
 }
 
-.courses.block .button-container.courses-button {
+.courses-wrapper .courses.block .button-container.courses-button {
     font-family: var(--font-gotham);
     font-weight: 700;
     font-size: 14px;
@@ -162,7 +161,7 @@
     justify-content: flex-end;
 }
 
-.courses.block .button-container .icon-container {
+.courses-wrapper .courses.block .button-container .icon-container {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -174,28 +173,28 @@
     transition: background .2s;
 }
 
-.courses.block .button-container:hover .icon-container {
+.courses-wrapper .courses.block .button-container:hover .icon-container {
     background: #000;
 }
 
 @media only screen and (max-width: 768px) {
-    .courses.block .courses-info-wrapper picture img:not(.gd-plus-icon) {
+    .courses-wrapper .courses.block .courses-info-wrapper picture img:not(.gd-plus-icon) {
         width: 100%; 
         height: auto; 
         max-height: 300px;
     }
 
-    .courses.block .courses-info-wrapper {
+    .courses-wrapper .courses.block .courses-info-wrapper {
         flex-direction: column;
     }
 
-    .courses.block p.courses-picture {
+    .courses-wrapper .courses.block p.courses-picture {
         flex-basis: 100%; 
         max-width: 100%;
         margin-right: 0;
     }
 
-    .courses.block .courses-text-wrapper {
+    .courses-wrapper .courses.block .courses-text-wrapper {
         margin-left: 0;
         width: 100%;
         margin-bottom: 30px;

--- a/blocks/default-article/default-article.css
+++ b/blocks/default-article/default-article.css
@@ -1,43 +1,43 @@
-.default-article.block .container {
+.default-article-wrapper .default-article.block .container {
     max-width: var(--layout-width);
     margin: 0 auto;
     padding: 20px;
 }
 
-.default-article.block .container .gd-plus-icon {
+.default-article-wrapper .default-article.block .container .gd-plus-icon {
     border-right: 2px solid #f6f6f6;
     margin-right: 10px;
     padding-right: 10px;
 }
 
-.default-article.block .container-article {
+.default-article-wrapper .default-article.block .container-article {
     display: flex;
     justify-content: space-between;
     margin-bottom: 30px;
 }
 
 @media (max-width: 768px) {
-    .default-article.block .container-article {
+    .default-article-wrapper .default-article.block .container-article {
         flex-direction: column;
     }
 }
 
-.default-article.block .article-content {
+.default-article-wrapper .default-article.block .article-content {
     max-width: 912px;
 }
 
-.default-article.block .container-aside {
+.default-article-wrapper .default-article.block .container-aside {
     padding-left: 10px;
 }
 
 @media (max-width: 768px) {
-    .default-article.block .container-aside {
+    .default-article-wrapper .default-article.block .container-aside {
         margin-top: 40px;
         margin-right: 10px;
     }
 }
 
-.default-article.block .rubric {
+.default-article-wrapper .default-article.block .rubric {
     color: #adb4b7;
     display: flex;
     align-items: center;
@@ -50,25 +50,25 @@
     margin-bottom: 8px;
 }
 
-.default-article.block .title h1 {
+.default-article-wrapper .default-article.block .title h1 {
     font-size: 40px;
     margin: 0.67em 0 20px;
     letter-spacing: .05em;
 }
 
 @media (max-width: 1280px) {
-    .default-article.block .title h1 {
+    .default-article-wrapper .default-article.block .title h1 {
         margin-block-start: 20px
     }
 }
 
-.default-article.block .byline {
+.default-article-wrapper .default-article.block .byline {
     display: flex;
     justify-content: flex-start;
     align-items: baseline;
 }
 
-.default-article.block .attribution {
+.default-article-wrapper .default-article.block .attribution {
     font-style: normal;
     font-weight: 700;
     letter-spacing: 0;
@@ -78,33 +78,33 @@
 }
 
 @media (min-width: 769px) {
-    .default-article.block .attribution {
+    .default-article-wrapper .default-article.block .attribution {
         font-size: 16px;
         line-height: 22px;
     }
 }
 
 @media (min-width: 1025px) {
-    .default-article.block .attribution {
+    .default-article-wrapper .default-article.block .attribution {
         margin-bottom: 10px;
     }
 }
 
-.default-article.block .article-body a {
+.default-article-wrapper .default-article.block .article-body a {
     font-weight: 500;
 }
 
-.default-article.block .attribution a {
+.default-article-wrapper .default-article.block .attribution a {
     color: #000;
     text-decoration: none;
 }
 
-.default-article.block .publication {
+.default-article-wrapper .default-article.block .publication {
     display: flex;
     align-items: baseline;
 }
 
-.default-article.block .publication::before {
+.default-article-wrapper .default-article.block .publication::before {
     content: "";
     display: block;
     border-left: 2px solid #e6e6e6;
@@ -112,53 +112,53 @@
     margin: 0 5px;
 }
 
-.default-article.block .byline .sharing {
+.default-article-wrapper .default-article.block .byline .sharing {
     display: flex;
     flex-grow: 1;
     justify-content: flex-end;
 }
 
 @media (max-width: 768px) {
-    .default-article.block .byline .sharing {
+    .default-article-wrapper .default-article.block .byline .sharing {
         display: none;
     }
 }
 
-.default-article.block .byline .sharing .social-share .label {
+.default-article-wrapper .default-article.block .byline .sharing .social-share .label {
     display: none;
 }
 
-.default-article.block .lead {
+.default-article-wrapper .default-article.block .lead {
     margin: 0 auto 20px;
 }
 
-.default-article.block .lead img {
+.default-article-wrapper .default-article.block .lead img {
     object-position: 50% 10%;
     width: 100%;
     object-fit: cover;
     height: auto;
 }
 
-.default-article.block .article-body img {
+.default-article-wrapper .default-article.block .article-body img {
     width: 100%;
     height: auto;
 }
 
-.default-article.block .lead .portrait {
+.default-article-wrapper .default-article.block .lead .portrait {
     display: flex;
     justify-content: center;
 }
 
-.default-article.block .lead .portrait img {
+.default-article-wrapper .default-article.block .lead .portrait img {
     max-width: 400px;
 }
 
-.default-article.block .credit {
+.default-article-wrapper .default-article.block .credit {
     margin: 0 auto;
     padding-top: 15px;
 }
 
-.default-article.block .credit span {
+.default-article-wrapper .default-article.block .credit span {
     color: #adb4b7;
     font-size: 12px;
     font-style: normal;
@@ -167,7 +167,7 @@
     letter-spacing: 0;
 }
 
-.default-article.block .credit p {
+.default-article-wrapper .default-article.block .credit p {
     font-size: 12px;
     font-style: normal;
     font-weight: 400;
@@ -176,13 +176,13 @@
     margin: 0;
 }
 
-.default-article.block .article-body {
+.default-article-wrapper .default-article.block .article-body {
     max-width: 765px;
     margin-right: 0;
     margin-left: auto;
 }
 
-.default-article.block .article-body > div p {
+.default-article-wrapper .default-article.block .article-body > div p {
     margin: 0 auto 30px;
     font-size: 16px;
     font-style: normal;
@@ -191,12 +191,12 @@
 }
 
 @media (min-width: 1025px) {
-    .default-article.block .article-body > div p {
+    .default-article-wrapper .default-article.block .article-body > div p {
         margin-bottom: 60px;
     }
 }
 
-.default-article.block .article-body > div p:first-of-type::first-letter {
+.default-article-wrapper .default-article.block .article-body > div p:first-of-type::first-letter {
     color: #000;
     font-style: normal;
     font-weight: 700;
@@ -208,13 +208,13 @@
 }
 
 @media (min-width: 769px) {
-    .default-article.block .article-body > div p:first-of-type::first-letter {
+    .default-article-wrapper .default-article.block .article-body > div p:first-of-type::first-letter {
         font-size: 150px;
         line-height: 85%;
     }
 }
 
-.default-article.block .article-body .photo-credit {
+.default-article-wrapper .default-article.block .article-body .photo-credit {
     font-size: 12px;
     line-height: 16px;
     color: #adb4b7;
@@ -222,11 +222,11 @@
     margin-bottom: 50px;
 }
 
-.default-article.block .article-body .portrait {
+.default-article-wrapper .default-article.block .article-body .portrait {
     display: flex;
     justify-content: center;
 }
 
-.default-article.block .article-body .portrait img {
+.default-article-wrapper .default-article.block .article-body .portrait img {
     max-width: 600px;
 }

--- a/blocks/editors-note/editors-note.css
+++ b/blocks/editors-note/editors-note.css
@@ -1,16 +1,16 @@
 
-.editors-note.block .editors-note-content i {
+.editors-note-wrapper .editors-note.block .editors-note-content i {
   font-size: 16px;
   font-family: var(--font-gotham);
   font-weight: 500;
 }
 
 @media (min-width: 769px) {
-  .editors-note.block .editors-note-content i {
+  .editors-note-wrapper .editors-note.block .editors-note-content i {
     font-size: 18px;
   }
 }
 
-.editors-note.block .editors-note-content i a {
+.editors-note-wrapper .editors-note.block .editors-note-content i a {
   color: #00e;
 }

--- a/blocks/full-bleed/full-bleed.css
+++ b/blocks/full-bleed/full-bleed.css
@@ -1,34 +1,34 @@
-.full-bleed.block .container {
+.full-bleed-wrapper .full-bleed.block .container {
   margin: 0 auto;
 }
 
-.full-bleed.block .gd-plus-icon {
+.full-bleed-wrapper .full-bleed.block .gd-plus-icon {
   padding-right: 10px;
   margin-right: 10px;
   border-right: solid 2px white;
   box-sizing: content-box;
 }
 
-.full-bleed.block .gd-plus-icon.dark {
+.full-bleed-wrapper .full-bleed.block .gd-plus-icon.dark {
   display: none;
 }
 
 @media (max-width: 768px) {
-  .full-bleed.block .gd-plus-icon.dark {
+  .full-bleed-wrapper .full-bleed.block .gd-plus-icon.dark {
     display: block;
   }
 
-  .full-bleed.block .gd-plus-icon.light {
+  .full-bleed-wrapper .full-bleed.block .gd-plus-icon.light {
     display: none;
   }
 }
 
-.full-bleed.block .credit {
+.full-bleed-wrapper .full-bleed.block .credit {
   margin: 0 auto;
   padding: 15px;
 }
 
-.full-bleed.block .credit span {
+.full-bleed-wrapper .full-bleed.block .credit span {
   color: #adb4b7;
   font-size: 12px;
   font-style: normal;
@@ -37,7 +37,7 @@
   letter-spacing: 0;
 }
 
-.full-bleed.block .credit p {
+.full-bleed-wrapper .full-bleed.block .credit p {
   font-size: 12px;
   font-style: normal;
   font-weight: 400;
@@ -46,14 +46,14 @@
   margin: 0;
 }
 
-.full-bleed.block .lead {
+.full-bleed-wrapper .full-bleed.block .lead {
   display: flex;
   flex-direction: column-reverse;
   position: relative;
 }
 
 @media (min-width: 769px) {
-  .full-bleed.block .lead {
+  .full-bleed-wrapper .full-bleed.block .lead {
     display: grid;
     grid-template-rows: 750px auto;
     grid-template-columns:
@@ -62,16 +62,16 @@
   }
 }
 
-.full-bleed.block .first-paragraph {
+.full-bleed-wrapper .full-bleed.block .first-paragraph {
   color: blue;
 }
 
-.full-bleed.block .headline {
+.full-bleed-wrapper .full-bleed.block .headline {
   padding: 15px;
 }
 
 @media (min-width: 769px) {
-  .full-bleed.block .headline {
+  .full-bleed-wrapper .full-bleed.block .headline {
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -85,7 +85,7 @@
   }
 }
 
-.full-bleed.block .headline .rubric {
+.full-bleed-wrapper .full-bleed.block .headline .rubric {
   font-size: 10px;
   margin-bottom: 20px;
   display: flex;
@@ -97,12 +97,12 @@
 }
 
 @media (min-width: 769px) {
-  .full-bleed.block .headline .rubric {
+  .full-bleed-wrapper .full-bleed.block .headline .rubric {
     font-size: 10px;
   }
 }
 
-.full-bleed.block .headline > .title > h1 {
+.full-bleed-wrapper .full-bleed.block .headline > .title > h1 {
   font-size: 40px;
   font-style: normal;
   font-weight: 700;
@@ -111,7 +111,7 @@
 }
 
 @media (min-width: 769px) {
-  .full-bleed.block .headline h1 {
+  .full-bleed-wrapper .full-bleed.block .headline h1 {
     text-align: center;
     margin-top: 0;
     margin-bottom: 20px;
@@ -121,7 +121,7 @@
 }
 
 
-.full-bleed.block .article-body div > p {
+.full-bleed-wrapper .full-bleed.block .article-body div > p {
   margin: 0 auto 30px;
   font-size: 16px;
   font-style: normal;
@@ -129,7 +129,7 @@
   line-height: 30px;
 }
 
-.full-bleed.block .headline > .title > p {
+.full-bleed-wrapper .full-bleed.block .headline > .title > p {
     font-weight: 400;
     color: white;
     margin: 40px 0 10px;
@@ -138,24 +138,24 @@
 }
 
 @media (min-width: 769px) {
-  .full-bleed.block .article-body div > p {
+  .full-bleed-wrapper .full-bleed.block .article-body div > p {
     margin-bottom: 60px;
   }
 }
 
-.full-bleed.block .attribution a {
+.full-bleed-wrapper .full-bleed.block .attribution a {
   color: #000;
   text-decoration: none;
 }
 
-.full-bleed.block .publication {
+.full-bleed-wrapper .full-bleed.block .publication {
   display: flex;
   align-items: baseline;
   letter-spacing: -0.03em;
   font-weight: 100;
 }
 
-.full-bleed.block .publication:not(:empty)::before {
+.full-bleed-wrapper .full-bleed.block .publication:not(:empty)::before {
   content: "";
   display: block;
   border-left: 2px solid #e6e6e6;
@@ -163,17 +163,17 @@
   margin: 0 10px;
 }
 
-.full-bleed.block .editors-note.block {
+.full-bleed-wrapper .full-bleed.block .editors-note.block {
   padding: 0 20px;
   max-width: 950px;
   margin: 0 auto;
 }
 
-.full-bleed.block .lead .editors-note.block {
+.full-bleed-wrapper .full-bleed.block .lead .editors-note.block {
   display: none;
 }
 
-.full-bleed.block .byline {
+.full-bleed-wrapper .full-bleed.block .byline {
   display: flex;
   height: 10px;
   justify-content: space-between;
@@ -183,32 +183,32 @@
 }
 
 @media (max-width: 768px) {
-  .full-bleed.block .byline {
+  .full-bleed-wrapper .full-bleed.block .byline {
     display: none;
   }
 
-  .full-bleed.block .lead .editors-note.block {
+  .full-bleed-wrapper .full-bleed.block .lead .editors-note.block {
     display: block;
   }
 
-  .full-bleed.block .article-content .editors-note.block {
+  .full-bleed-wrapper .full-bleed.block .article-content .editors-note.block {
     display: none;
   }
 }
 
-.full-bleed.block .lead > .byline .sharing {
+.full-bleed-wrapper .full-bleed.block .lead > .byline .sharing {
   grid-column: 2;
   display: flex;
   justify-content: flex-end;
   z-index: 2;
 }
 
-.full-bleed.block .lead > .byline .publication {
+.full-bleed-wrapper .full-bleed.block .lead > .byline .publication {
   grid-column: 1;
   grid-row: 1;
 }
 
-.full-bleed.block .attribution {
+.full-bleed-wrapper .full-bleed.block .attribution {
   grid-column: 1;
   grid-row: 1;
   display: flex;
@@ -219,51 +219,51 @@
   margin-bottom: 45px;
 }
 
-.full-bleed.block .attribution > span {
+.full-bleed-wrapper .full-bleed.block .attribution > span {
   margin-right: 5px;
 }
 
-.full-bleed.block .lead > .byline .attribution > span:first-of-type {
+.full-bleed-wrapper .full-bleed.block .lead > .byline .attribution > span:first-of-type {
   margin-right: 5px;
 }
 
-.full-bleed.block .headline .byline {
+.full-bleed-wrapper .full-bleed.block .headline .byline {
   display: flex;
   height: 10px;
   justify-content: flex-start;
 }
 
 @media (min-width: 769px) {
-  .full-bleed.block .headline .byline {
+  .full-bleed-wrapper .full-bleed.block .headline .byline {
     display: none;
   }
 }
 
 @media (max-width: 768px) {
-  .full-bleed.block .lead > .byline {
+  .full-bleed-wrapper .full-bleed.block .lead > .byline {
     display: none;
   }
 }
 
 @media (min-width: 769px) {
-  .full-bleed.block .credit {
+  .full-bleed-wrapper .full-bleed.block .credit {
     display: none;
   }
 }
 
 @media (max-width: 769px) {
-  .full-bleed.block .headline > .title > h1 {
+  .full-bleed-wrapper .full-bleed.block .headline > .title > h1 {
     text-align: left;
   }
 }
 
-.full-bleed.block .lead .image {
+.full-bleed-wrapper .full-bleed.block .lead .image {
   grid-column: 1/-1;
   grid-row: 1;
   height: 100%;
 }
 
-.full-bleed.block.block .article-body .photo-credit {
+.full-bleed-wrapper .full-bleed.block.block .article-body .photo-credit {
     color: #adb4b7;
     font-size: 12px;
     font-style: normal;
@@ -274,14 +274,14 @@
 }
 
 @media (min-width: 1025px) {
-  .full-bleed.block .lead picture {
+  .full-bleed-wrapper .full-bleed.block .lead picture {
     position: absolute;
     left: 0;
     top: 0;
   }
 }
 
-.full-bleed.block .lead picture {
+.full-bleed-wrapper .full-bleed.block .lead picture {
   display: block;
   width: 100%;
   height: 100%;
@@ -292,7 +292,7 @@
   position: relative;
 }
 
-.full-bleed.block .lead picture::after {
+.full-bleed-wrapper .full-bleed.block .lead picture::after {
   z-index: 1;
   background: linear-gradient(
     0.01deg,
@@ -311,12 +311,12 @@
 }
 
 @media (max-width: 768px) {
-  .full-bleed.block .lead picture::after {
+  .full-bleed-wrapper .full-bleed.block .lead picture::after {
     display: none;
   }
 }
 
-.full-bleed.block .lead img:not(.gd-plus-icon) {
+.full-bleed-wrapper .full-bleed.block .lead img:not(.gd-plus-icon) {
   object-position: 50% 10%;
   height: auto;
   max-height: 680px;
@@ -325,53 +325,53 @@
 }
 
 @media (max-width: 768px) {
-  .full-bleed.block .lead img:not(.gd-plus-icon) {
+  .full-bleed-wrapper .full-bleed.block .lead img:not(.gd-plus-icon) {
     height: auto;
     object-fit: cover;
   }
 }
 
-.full-bleed.block .article-body a {
+.full-bleed-wrapper .full-bleed.block .article-body a {
   color: #000;
   font-weight: 600;
 }
 
-.full-bleed.block .attribution a:hover {
+.full-bleed-wrapper .full-bleed.block .attribution a:hover {
   text-decoration: underline;
 }
 
 @media (min-width: 769px) {
-  .full-bleed.block .publication {
+  .full-bleed-wrapper .full-bleed.block .publication {
     margin-bottom: 42px;
   }
 }
 
-.full-bleed.block .byline .social-share .label {
+.full-bleed-wrapper .full-bleed.block .byline .social-share .label {
   display: none;
 }
 
-.full-bleed.block .lead > .byline .social-share .columns {
+.full-bleed-wrapper .full-bleed.block .lead > .byline .social-share .columns {
   flex-wrap: wrap;
   justify-content: flex-end;
 }
 
-.full-bleed.block .article-body {
+.full-bleed-wrapper .full-bleed.block .article-body {
   max-width: 800px;
   margin: auto;
   padding: 0 20px 20px;
 }
 
-.full-bleed.block .article-body div > p.highlight {
+.full-bleed-wrapper .full-bleed.block .article-body div > p.highlight {
   font-size: 18px;
   margin-top: 0;
 }
 
-.full-bleed.block .article-body img:not(.gd-plus-icon) {
+.full-bleed-wrapper .full-bleed.block .article-body img:not(.gd-plus-icon) {
   width: 100%;
   height: auto;
 }
 
-.full-bleed.block .article-body a:hover {
+.full-bleed-wrapper .full-bleed.block .article-body a:hover {
   color: var(--link-hover-color);
 }
 
@@ -393,12 +393,12 @@
   }
 }
 
-.full-bleed.block .center-seperator {
+.full-bleed-wrapper .full-bleed.block .center-seperator {
   display: flex;
   justify-content: center;
 }
 
-.full-bleed.block h2 {
+.full-bleed-wrapper .full-bleed.block h2 {
   font-weight: 700;
   background-image: linear-gradient(to bottom, transparent calc(100% - 2px), #ed3e49 calc(100% - 2px), #ed3e49 100%);
   background-repeat: repeat-y;
@@ -412,22 +412,22 @@
   box-decoration-break: clone;
 }
 
-.full-bleed.block .article-body .centered-h2 {
+.full-bleed-wrapper .full-bleed.block .article-body .centered-h2 {
   text-align: center;
   margin-bottom: 50px;
 }
 
-.full-bleed.block .container-article {
+.full-bleed-wrapper .full-bleed.block .container-article {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
 }
 
-.full-bleed.block .article-content {
+.full-bleed-wrapper .full-bleed.block .article-content {
   flex: 1;
 }
 
-.full-bleed.block .container-aside {
+.full-bleed-wrapper .full-bleed.block .container-aside {
   min-width: 200px;
   width: 20%;
   max-width: 100%;
@@ -435,13 +435,13 @@
   margin-right: 40px;
 }
 
-.full-bleed.block .content-wrapper {
+.full-bleed-wrapper .full-bleed.block .content-wrapper {
   display: flex;
   flex-direction: row;
 }
 
 @media (max-width: 768px) {
-  .full-bleed.block .content-wrapper {
+  .full-bleed-wrapper .full-bleed.block .content-wrapper {
       flex-direction: column;
   }
 }

--- a/blocks/gallery-listicle/gallery-listicle.css
+++ b/blocks/gallery-listicle/gallery-listicle.css
@@ -1,21 +1,21 @@
-.gallery-listicle.block {
+.gallery-listicle-wrapper .gallery-listicle.block {
     -moz-osx-font-smoothing: grayscale;
     -webkit-font-smoothing: antialiased;
 }
 
-.gallery-listicle.block .container {
+.gallery-listicle-wrapper .gallery-listicle.block .container {
     max-width: var(--layout-width);
     margin: 30px auto 0;
     padding: 20px;
 }
 
-.gallery-listicle.block .container-article {
+.gallery-listicle-wrapper .gallery-listicle.block .container-article {
     display: flex;
     justify-content: space-between;
     margin-bottom: 30px;
 }
 
-.gallery-listicle.block .container-article img {
+.gallery-listicle-wrapper .gallery-listicle.block .container-article img {
     width: 100%;
     height: auto;
     object-fit: contain;
@@ -23,27 +23,27 @@
 }
 
 @media (max-width: 768px) {
-    .gallery-listicle.block .container-article {
+    .gallery-listicle-wrapper .gallery-listicle.block .container-article {
         flex-direction: column;
     }
 }
 
-.gallery-listicle.block .article-content,
-.gallery-listicle.block .container-aside {
+.gallery-listicle-wrapper .gallery-listicle.block .article-content,
+.gallery-listicle-wrapper .gallery-listicle.block .container-aside {
     padding: 0 10px;
 }
 
 @media (min-width: 1024px) {
-    .gallery-listicle.block .article-content {
+    .gallery-listicle-wrapper .gallery-listicle.block .article-content {
         width: 72%;
     }
 
-    .gallery-listicle.block .container-aside {
+    .gallery-listicle-wrapper .gallery-listicle.block .container-aside {
         width: 28%;
     }
 }
 
-.gallery-listicle.block .rubric {
+.gallery-listicle-wrapper .gallery-listicle.block .rubric {
     color: #adb4b7;
     display: flex;
     align-items: center;
@@ -57,31 +57,31 @@
 }
 
 @media (min-width: 769px) {
-    .gallery-listicle.block .rubric {
+    .gallery-listicle-wrapper .gallery-listicle.block .rubric {
         font-size: 13px;
         line-height: 12.44px;
     }
 }
 
-.gallery-listicle.block .headline h1 {
+.gallery-listicle-wrapper .gallery-listicle.block .headline h1 {
     font-size: 40px;
     margin: 0.67em 0 20px;
 }
 
 @media (max-width: 1280px) {
-    .gallery-listicle.block .headline h1 {
+    .gallery-listicle-wrapper .gallery-listicle.block .headline h1 {
         margin-block-start: 20px
     }
 }
 
-.gallery-listicle.block .headline p {
+.gallery-listicle-wrapper .gallery-listicle.block .headline p {
     font-size: 18px;
     line-height: 30px;
     margin: 20px 0;
     font-weight: 500;
 }
 
-.gallery-listicle.block .article-body > div p {
+.gallery-listicle-wrapper .gallery-listicle.block .article-body > div p {
     margin: 0 auto 30px;
     font-size: 18px;
     font-style: normal;
@@ -89,13 +89,13 @@
     line-height: 30px;
 }
 
-.gallery-listicle.block .byline {
+.gallery-listicle-wrapper .gallery-listicle.block .byline {
     display: flex;
     justify-content: flex-start;
     align-items: baseline;
 }
 
-.gallery-listicle.block .attribution {
+.gallery-listicle-wrapper .gallery-listicle.block .attribution {
     font-style: normal;
     font-weight: 700;
     letter-spacing: 0;
@@ -104,42 +104,42 @@
     margin-bottom: 45px;
 }
 
-.gallery-listicle.block .byline.no-author .attribution {
+.gallery-listicle-wrapper .gallery-listicle.block .byline.no-author .attribution {
     display: none;
 }
 
 @media (min-width: 769px) {
-    .gallery-listicle.block .attribution {
+    .gallery-listicle-wrapper .gallery-listicle.block .attribution {
         font-size: 16px;
         line-height: 22px;
     }
 }
 
 @media (min-width: 1025px) {
-    .gallery-listicle.block .attribution {
+    .gallery-listicle-wrapper .gallery-listicle.block .attribution {
         margin-bottom: 10px;
     }
 }
 
-.gallery-listicle.block .attribution a {
+.gallery-listicle-wrapper .gallery-listicle.block .attribution a {
     color: #000;
     text-decoration: none;
 }
 
-.gallery-listicle.block .article-body > div a {
+.gallery-listicle-wrapper .gallery-listicle.block .article-body > div a {
     color: black;
     text-decoration: none;
 }
 
-.gallery-listicle.block .article-body strong > a {
+.gallery-listicle-wrapper .gallery-listicle.block .article-body strong > a {
     text-decoration: underline;
 }
 
-.gallery-listicle.block .article-body > div a:hover {
+.gallery-listicle-wrapper .gallery-listicle.block .article-body > div a:hover {
     color: var(--link-hover-color);
 }
 
-.gallery-listicle.block .publication {
+.gallery-listicle-wrapper .gallery-listicle.block .publication {
     display: flex;
     align-items: baseline;
     color: #adb4b7;
@@ -147,7 +147,7 @@
     font-weight: 700;
 }
 
-.gallery-listicle.block .publication::before {
+.gallery-listicle-wrapper .gallery-listicle.block .publication::before {
     content: "";
     display: block;
     border-left: 2px solid #e6e6e6;
@@ -155,27 +155,27 @@
     margin: 0 5px;
 }
 
-.gallery-listicle.block .byline .sharing {
+.gallery-listicle-wrapper .gallery-listicle.block .byline .sharing {
     display: flex;
     flex-grow: 1;
     justify-content: flex-end;
 }
 
 @media (max-width: 768px) {
-    .gallery-listicle.block .byline .sharing {
+    .gallery-listicle-wrapper .gallery-listicle.block .byline .sharing {
         display: none;
     }
 }
 
-.gallery-listicle.block .social-share .label {
+.gallery-listicle-wrapper .gallery-listicle.block .social-share .label {
     display: none;
 }
 
-.gallery-listicle.block .social-share .columns {
+.gallery-listicle-wrapper .gallery-listicle.block .social-share .columns {
     gap: 8px;
 }
 
-.gallery-listicle.block .article-body h2 {
+.gallery-listicle-wrapper .gallery-listicle.block .article-body h2 {
     display: inline-flex;
     height: 35px;
     width: 35px;
@@ -189,7 +189,7 @@
     margin-bottom: 0;
 }
 
-.gallery-listicle.block .article-body .photo-credit {
+.gallery-listicle-wrapper .gallery-listicle.block .article-body .photo-credit {
     font-size: 12px;
     line-height: 16px;
     color: #adb4b7;

--- a/blocks/gallery/gallery.css
+++ b/blocks/gallery/gallery.css
@@ -1,26 +1,26 @@
-.gallery.block {
+.gallery-wrapper .gallery.block {
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
 }
 
-.gallery.block .container {
+.gallery-wrapper .gallery.block .container {
   max-width: var(--layout-width);
   margin: 0 auto;
   padding: 20px;
 }
 
-.gallery.block .container-article {
+.gallery-wrapper .gallery.block .container-article {
   display: flex;
   justify-content: space-between;
   margin-bottom: 30px;
 }
 
-.gallery.block .container-article picture {
+.gallery-wrapper .gallery.block .container-article picture {
   display: flex;
   background-color: #f2f2f2;
 }
 
-.gallery.block .container-article img:not(.gd-plus-icon) {
+.gallery-wrapper .gallery.block .container-article img:not(.gd-plus-icon) {
   width: 100%;
   height: auto;
   object-fit: contain;
@@ -28,33 +28,33 @@
   padding: 15px;
 }
 
-.gallery.block .container-article img.portrait {
+.gallery-wrapper .gallery.block .container-article img.portrait {
   width: 50%;
   padding: 0;
 }
 
 @media (max-width: 768px) {
-  .gallery.block .container-article {
+  .gallery-wrapper .gallery.block .container-article {
     flex-direction: column;
   }
 }
 
-.gallery.block .article-content,
-.gallery.block .container-aside {
+.gallery-wrapper .gallery.block .article-content,
+.gallery-wrapper .gallery.block .container-aside {
   padding: 0 10px;
 }
 
 @media (min-width: 1024px) {
-  .gallery.block .article-content {
+  .gallery-wrapper .gallery.block .article-content {
     width: 72%;
   }
 
-  .gallery.block .container-aside {
+  .gallery-wrapper .gallery.block .container-aside {
     width: 28%;
   }
 }
 
-.gallery.block .rubric {
+.gallery-wrapper .gallery.block .rubric {
   color: #adb4b7;
   display: flex;
   align-items: center;
@@ -68,24 +68,24 @@
 }
 
 @media (min-width: 769px) {
-  .gallery.block .rubric {
+  .gallery-wrapper .gallery.block .rubric {
     font-size: 13px;
     line-height: 12.44px;
   }
 }
 
-.gallery.block .headline h1 {
+.gallery-wrapper .gallery.block .headline h1 {
   font-size: 40px;
   margin: 0.67em 0 20px;
 }
 
 @media (max-width: 1280px) {
-  .gallery.block .headline h1 {
+  .gallery-wrapper .gallery.block .headline h1 {
     margin-block-start: 20px
   }
 }
 
-.gallery.block .article-body > div p {
+.gallery-wrapper .gallery.block .article-body > div p {
   margin: 0 auto 30px;
   font-size: 14px;
   font-style: normal;
@@ -93,24 +93,24 @@
   line-height: 19px;
 }
 
-.gallery.block .headline h1 + p {
+.gallery-wrapper .gallery.block .headline h1 + p {
   font-size: 18px;
   line-height: 30px;
   margin: 20px 0;
 }
 
-.gallery.block .headline h1 + p,
-.gallery.block .headline h1 + p strong {
+.gallery-wrapper .gallery.block .headline h1 + p,
+.gallery-wrapper .gallery.block .headline h1 + p strong {
   font-weight: 500;
 }
 
-.gallery.block .byline {
+.gallery-wrapper .gallery.block .byline {
   display: flex;
   justify-content: flex-start;
   align-items: baseline;
 }
 
-.gallery.block .attribution {
+.gallery-wrapper .gallery.block .attribution {
   font-style: normal;
   font-weight: 700;
   letter-spacing: 0;
@@ -120,41 +120,41 @@
 }
 
 @media (min-width: 769px) {
-  .gallery.block .attribution {
+  .gallery-wrapper .gallery.block .attribution {
     font-size: 16px;
     line-height: 22px;
   }
 }
 
 @media (min-width: 1025px) {
-  .gallery.block .attribution {
+  .gallery-wrapper .gallery.block .attribution {
     margin-bottom: 10px;
   }
 }
 
-.gallery.block .byline.no-author .attribution {
+.gallery-wrapper .gallery.block .byline.no-author .attribution {
   display: none;
 }
 
-.gallery.block .attribution a {
+.gallery-wrapper .gallery.block .attribution a {
   color: #000;
   text-decoration: none;
 }
 
-.gallery.block .article-body > div a {
+.gallery-wrapper .gallery.block .article-body > div a {
   color: black;
   text-decoration: none;
 }
 
-.gallery.block .article-body > div a:hover {
+.gallery-wrapper .gallery.block .article-body > div a:hover {
   color: var(--link-hover-color);
 }
 
-.gallery.block .article-body .social-share {
+.gallery-wrapper .gallery.block .article-body .social-share {
   margin-top: 72px;
 }
 
-.gallery.block .publication {
+.gallery-wrapper .gallery.block .publication {
   display: flex;
   align-items: baseline;
   color: #adb4b7;
@@ -162,7 +162,7 @@
   font-weight: 700;
 }
 
-.gallery.block .publication::before {
+.gallery-wrapper .gallery.block .publication::before {
   content: "";
   display: block;
   border-left: 2px solid #e6e6e6;
@@ -170,46 +170,46 @@
   margin: 0 5px;
 }
 
-.gallery.block .byline.no-author .publication::before {
+.gallery-wrapper .gallery.block .byline.no-author .publication::before {
   display: none;
 }
 
-.gallery.block .byline .sharing {
+.gallery-wrapper .gallery.block .byline .sharing {
   display: flex;
   flex-grow: 1;
   justify-content: flex-end;
 }
 
-.gallery.block .byline .sharing .social-share .label {
+.gallery-wrapper .gallery.block .byline .sharing .social-share .label {
   display: none;
 }
 
 @media (max-width: 768px) {
-  .gallery.block .byline .sharing {
+  .gallery-wrapper .gallery.block .byline .sharing {
     display: none;
   }
 }
 
-.gallery.block .social-share .columns {
+.gallery-wrapper .gallery.block .social-share .columns {
   gap: 8px;
 }
 
-.gallery.block .carousel {
+.gallery-wrapper .gallery.block .carousel {
   display: flex;
   justify-content: center;
   align-items: center;
   position: relative;
 }
 
-.gallery.block .carousel.is-transitioning {
+.gallery-wrapper .gallery.block .carousel.is-transitioning {
   visibility: hidden;
 }
 
-.gallery.block .carousel > div {
+.gallery-wrapper .gallery.block .carousel > div {
   width: 100%;
 }
 
-.gallery.block .carousel > div h3 {
+.gallery-wrapper .gallery.block .carousel > div h3 {
   margin: 0;
   padding-left: 20px;
   font-size: 24px;
@@ -217,12 +217,12 @@
   line-height: 23px;
 }
 
-.gallery.block .carousel > div > p:first-of-type {
+.gallery-wrapper .gallery.block .carousel > div > p:first-of-type {
   position: relative;
   margin: 0;
 }
 
-.gallery.block .carousel > div > p:not(:first-of-type) {
+.gallery-wrapper .gallery.block .carousel > div > p:not(:first-of-type) {
   padding-top: 20px;
   padding-left: 20px;
   max-width: 780px;
@@ -230,12 +230,12 @@
   margin-top: 0;
 }
 
-.gallery.block .carousel > div > p:last-of-type {
+.gallery-wrapper .gallery.block .carousel > div > p:last-of-type {
   margin-bottom: 0;
 }
 
-.gallery.block .carousel .next,
-.gallery.block .carousel .prev {
+.gallery-wrapper .gallery.block .carousel .next,
+.gallery-wrapper .gallery.block .carousel .prev {
   position: absolute;
   top: calc(50% - 25px);
   color: #fff;
@@ -250,26 +250,26 @@
   border-radius: 50%;
 }
 
-.gallery.block .carousel .next {
+.gallery-wrapper .gallery.block .carousel .next {
   right: 27px;
 }
 
-.gallery.block .carousel .next span {
+.gallery-wrapper .gallery.block .carousel .next span {
   display: none;
 }
 
-.gallery.block .carousel .prev {
+.gallery-wrapper .gallery.block .carousel .prev {
   left: 27px;
 }
 
-.gallery.block .carousel .next.has-label {
+.gallery-wrapper .gallery.block .carousel .next.has-label {
   border-radius: 3rem;
   height: 50px;
   width: auto;
   padding-left: 28px;
 }
 
-.gallery.block .carousel .next.has-label span {
+.gallery-wrapper .gallery.block .carousel .next.has-label span {
   display: inline ;
   text-transform: uppercase;
   font-size: 12px;
@@ -280,20 +280,20 @@
   padding-right: 10px;
 }
 
-.gallery.block .carousel .next svg,
-.gallery.block .carousel .prev svg {
+.gallery-wrapper .gallery.block .carousel .next svg,
+.gallery-wrapper .gallery.block .carousel .prev svg {
   width: 27px;
   height: 27px;
 }
 
-.gallery.block .carousel .count {
+.gallery-wrapper .gallery.block .carousel .count {
   font-weight: 500;
   text-align: right;
   margin-right: 8px;
   margin-top: 8px;
 }
 
-.gallery.block .carousel div.photo-credit {
+.gallery-wrapper .gallery.block .carousel div.photo-credit {
   position: absolute;
   bottom: 52px;
   left: 20px;
@@ -307,7 +307,7 @@
   display: inline-block;
 }
 
-.gallery.block .carousel span.photo-credit {
+.gallery-wrapper .gallery.block .carousel span.photo-credit {
   color: #adb4b7;
   font-size: 14px;
   padding-left: 20px;

--- a/blocks/gdplus-subscribe-hero/gdplus-subscribe-hero.css
+++ b/blocks/gdplus-subscribe-hero/gdplus-subscribe-hero.css
@@ -1,17 +1,17 @@
 /*
 * Main wrapper
 */
-.gdplus-subscribe-hero.block {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block {
   margin: 40px 0;
   position: relative;
   background-color: #EDEDED;
 }
 
-.gdplus-subscribe-hero.block .red-plus {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .red-plus {
   color: #ed3e49;
 }
 
-.gdplus-subscribe-hero.block .gd-plus-subscribe-content {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .gd-plus-subscribe-content {
   position: relative;
   display: flex;
   flex-direction: column;
@@ -23,7 +23,7 @@
   margin-bottom: 155px;
 }
 
-.gdplus-subscribe-hero.block .gd-plus-subscribe-content .background-image-wrapper {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .gd-plus-subscribe-content .background-image-wrapper {
   position: absolute;
   top: 0;
   left: 0;
@@ -31,7 +31,7 @@
   height: 100%;
 }
 
-.gdplus-subscribe-hero.block .gd-plus-subscribe-content .background-image-wrapper .image-overlay {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .gd-plus-subscribe-content .background-image-wrapper .image-overlay {
   background-color: #1f2022;
   width: 100%;
   height: 100%;
@@ -42,13 +42,13 @@
 }
 
 @media (max-width: 1297px) {
-  .gdplus-subscribe-hero.block .gd-plus-subscribe-content {
+  .gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .gd-plus-subscribe-content {
     min-height: auto;
     padding: 27px 22px 61px;
   }
 }
 
-.gdplus-subscribe-hero.block .subscribe-title {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .subscribe-title {
   margin: 0 0 10px;
   font-family: var(--font-tungsten);
   font-size: 50px;
@@ -60,7 +60,7 @@
   z-index: 1;
 }
 
-.gdplus-subscribe-hero.block .subscribe-subtitle {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .subscribe-subtitle {
   margin: 0 0 40px;
   font-family: var(--font-gotham);
   font-size: 20px;
@@ -73,7 +73,7 @@
 /*
 * Offers
 */
-.gdplus-subscribe-hero.block .offer-list {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .offer-list {
   list-style: none;
   padding: 0;
   margin: 0;
@@ -85,7 +85,7 @@
 }
 
 @media (max-width: 1297px) {
-  .gdplus-subscribe-hero.block .offer-list {
+  .gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .offer-list {
     flex-direction: column;
     align-items: center;
     gap: 20px;
@@ -93,7 +93,7 @@
   }
 }
 
-.gdplus-subscribe-hero.block .offer-card {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .offer-card {
   position: relative;
   display: flex;
   flex-direction: column;
@@ -108,22 +108,22 @@
   padding: 29px 30px;
 }
 
-.gdplus-subscribe-hero.block .offer-card.most-popular {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .offer-card.most-popular {
   padding-top: 46px;
 }
 
 @media (max-width: 1297px) {
-  .gdplus-subscribe-hero.block .offer-card {
+  .gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .offer-card {
     width: 100%;
     max-width: 420px;
   }
 
-  .gdplus-subscribe-hero.block .offer-card.most-popular {
+  .gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .offer-card.most-popular {
     order: -1;
   }
 }
 
-.gdplus-subscribe-hero.block .offer-card.most-popular::before {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .offer-card.most-popular::before {
   position: absolute;
   top: -16px;
   content: "Most Popular";
@@ -138,7 +138,7 @@
   background-color: #ed3e49;
 }
 
-.gdplus-subscribe-hero.block .offer-card .card-title {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .offer-card .card-title {
   margin: 0 0 18px;
   font-family: var(--font-gotham);
   font-style: normal;
@@ -149,11 +149,11 @@
   color: #000;
 }
 
-.gdplus-subscribe-hero.block .offer-card .price-wrapper {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .offer-card .price-wrapper {
   margin-bottom: 15px;
 }
 
-.gdplus-subscribe-hero.block .offer-card .price-wrapper > * {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .offer-card .price-wrapper > * {
   font-family: var(--font-tungsten);
   color: #000;
   font-style: normal;
@@ -165,18 +165,18 @@
   font-weight: 600;
 }
 
-.gdplus-subscribe-hero.block .offer-card .price-wrapper .scope {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .offer-card .price-wrapper .scope {
   margin: 0 0 15px;
 }
 
-.gdplus-subscribe-hero.block .offer-card .price-wrapper .price {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .offer-card .price-wrapper .price {
   font-size: 89px;
   line-height: 88%;
   text-align: center;
   letter-spacing: 0.01em;
 }
 
-.gdplus-subscribe-hero.block .offer-card .billing-info {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .offer-card .billing-info {
   margin: 0 0 25px;
   font-family: var(--font-gotham);
   font-weight: 325;
@@ -186,7 +186,7 @@
   color: #adb4b7;
 }
 
-.gdplus-subscribe-hero.block .offer-card .offer-button {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .offer-card .offer-button {
   cursor: pointer;
   margin: 0 0 30px;
   padding: 11px 40px;
@@ -203,19 +203,19 @@
   transition: background-color ease 0.6s, border ease 0.6s;
 }
 
-.gdplus-subscribe-hero.block .offer-card.most-popular .offer-button {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .offer-card.most-popular .offer-button {
   color: #fff;
   background-color: #ed3e49;
   border-color: #ed3e49;
 }
 
-.gdplus-subscribe-hero.block .offer-card .offer-button:hover {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .offer-card .offer-button:hover {
   background-color: #000;
   color: #fff;
   border-color: #000;
 }
 
-.gdplus-subscribe-hero.block .offer-card .offer-cancel {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .offer-card .offer-cancel {
   font-family: var(--font-gotham);
   font-weight: 325;
   font-size: 15px;
@@ -227,7 +227,7 @@
 /*
 * Gifting banner
 */
-.gdplus-subscribe-hero.block .gift-subscription-wrapper {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .gift-subscription-wrapper {
   width: 100%;
   max-width: 768px;
   color: #000;
@@ -237,7 +237,7 @@
   transform: translateY(calc(100% - 73px));
 }
 
-.gdplus-subscribe-hero.block .gift-subscription-wrapper .gift-content {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .gift-subscription-wrapper .gift-content {
   padding: 38px 40px;
   border: 1px solid #e6e6e6;
   box-shadow: 0 0 5px rgba(17 17 17 / 10%);
@@ -247,12 +247,12 @@
   align-items: center;
 }
 
-.gdplus-subscribe-hero.block .gift-subscription-wrapper .gift-content .text-wrapper {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .gift-subscription-wrapper .gift-content .text-wrapper {
   display: flex;
   flex-direction: column;
 }
 
-.gdplus-subscribe-hero.block .gift-subscription-wrapper .gift-content .text-wrapper .gift-title {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .gift-subscription-wrapper .gift-content .text-wrapper .gift-title {
   font-family: var(--font-tungsten);
   font-size: 37px;
   line-height: 104%;
@@ -263,7 +263,7 @@
   color: #000;
 }
 
-.gdplus-subscribe-hero.block .gift-subscription-wrapper .gift-content .text-wrapper .gift-description {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .gift-subscription-wrapper .gift-content .text-wrapper .gift-description {
   font-family: var(--font-gotham);
   font-weight: normal;
   font-size: 14px;
@@ -274,7 +274,7 @@
   margin: 0;
 }
 
-.gdplus-subscribe-hero.block .gift-subscription-wrapper .gift-content .gift-button {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .gift-subscription-wrapper .gift-content .gift-button {
   width: 127px;
   height: 40px;
   padding: 10px;
@@ -289,27 +289,27 @@
   transition: background-color ease 0.6s, border ease 0.6s, color ease 0.6s;
 }
 
-.gdplus-subscribe-hero.block .gift-subscription-wrapper .gift-content .gift-button:hover {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .gift-subscription-wrapper .gift-content .gift-button:hover {
   background-color: #000;
   color: #fff;
   border-color: #000;
 }
 
 @media (max-width: 768px) {
-  .gdplus-subscribe-hero.block .gift-subscription-wrapper .gift-content .text-wrapper .gift-title {
+  .gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .gift-subscription-wrapper .gift-content .text-wrapper .gift-title {
     text-align: center;
   }
 
-  .gdplus-subscribe-hero.block .gift-subscription-wrapper .gift-content .text-wrapper .gift-description {
+  .gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .gift-subscription-wrapper .gift-content .text-wrapper .gift-description {
     margin-bottom: 20px;
   }
 
-  .gdplus-subscribe-hero.block .gift-subscription-wrapper .gift-content {
+  .gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .gift-subscription-wrapper .gift-content {
     flex-direction: column;
     padding: 20px;
   }
 
-  .gdplus-subscribe-hero.block .gift-subscription-wrapper .hide-on-mobile {
+  .gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .gift-subscription-wrapper .hide-on-mobile {
     display: none;
   }
 }
@@ -319,7 +319,7 @@
 * Benefits styles
 */
 
-.gdplus-subscribe-hero.block .benefits-header {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .benefits-header {
   margin: 0 0 40px;
   font-family: var(--font-tungsten);
   font-weight: 600;
@@ -331,37 +331,37 @@
   text-align: center;
 }
 
-.gdplus-subscribe-hero.block .gd-plus-benefits-content {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .gd-plus-benefits-content {
   display: flex;
   align-items: center;
 }
 
-.gdplus-subscribe-hero.block .gd-plus-benefits-content picture {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .gd-plus-benefits-content picture {
   width: 714px;
   height: 394px;
   flex: 0 0 714px;
   margin-right: 93px;
 }
 
-.gdplus-subscribe-hero.block .gd-plus-benefits-content img {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .gd-plus-benefits-content img {
   width: 714px;
   height: 394px;
   flex: 0 0 714px;
   margin-right: 93px;
 }
 
-.gdplus-subscribe-hero.block .gd-plus-benefits-content .benefits-list {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .gd-plus-benefits-content .benefits-list {
   list-style: none;
   margin: 0;
   padding: 0;
 }
 
-.gdplus-subscribe-hero.block .gd-plus-benefits-content .benefit-item {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .gd-plus-benefits-content .benefit-item {
   margin: 0 0 30px;
   padding: 0;
 }
 
-.gdplus-subscribe-hero.block .gd-plus-benefits-content .benefit-item .benefit-title {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .gd-plus-benefits-content .benefit-item .benefit-title {
   font-family: var(--font-gotham);
   font-weight: 500;
   font-size: 20px;
@@ -370,7 +370,7 @@
   display: flex;
 }
 
-.gdplus-subscribe-hero.block .gd-plus-benefits-content .benefit-item .benefit-title::before {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .gd-plus-benefits-content .benefit-item .benefit-title::before {
   display: block;
   content: "";
   width: 10px;
@@ -383,7 +383,7 @@
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='9' viewBox='0 0 8 9' fill='none'%3E%3Ccircle cx='4' cy='4.5' r='4' fill='%23ED3E49'/%3E%3C/svg%3E");
 }
 
-.gdplus-subscribe-hero.block .gd-plus-benefits-content .benefit-item .info {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .gd-plus-benefits-content .benefit-item .info {
   font-family: var(--font-gotham);
   font-weight: 325;
   font-size: 10px;
@@ -394,11 +394,11 @@
 }
 
 @media (max-width: 1297px) {
-  .gdplus-subscribe-hero.block .gd-plus-benefits-content {
+  .gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .gd-plus-benefits-content {
     flex-direction: column;
   }
 
-  .gdplus-subscribe-hero.block .gd-plus-benefits-content picture {
+  .gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .gd-plus-benefits-content picture {
     order: 1;
     width: 100%;
     height: auto;
@@ -406,14 +406,14 @@
     margin: 0;
   }
 
-  .gdplus-subscribe-hero.block .gd-plus-benefits-content img {
+  .gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .gd-plus-benefits-content img {
     width: 100%;
     height: auto;
     margin: 0;
   }
 }
 
-.gdplus-subscribe-hero.block .gd-plus-subscribe-content .background-image-wrapper picture {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .gd-plus-subscribe-content .background-image-wrapper picture {
   position: absolute;
   width: 100%;
   height: 100%;
@@ -421,7 +421,7 @@
   object-position: 50% 50%;
 }
 
-.gdplus-subscribe-hero.block .gd-plus-subscribe-content .background-image-wrapper img {
+.gdplus-subscribe-hero-wrapper .gdplus-subscribe-hero.block .gd-plus-subscribe-content .background-image-wrapper img {
   width: 100%;
   height: 100%;
   object-fit: cover;

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -1,20 +1,20 @@
-.hero.block {
+.hero-wrapper .hero.block {
     display: grid;
     grid-template-columns: 1fr min(var(--layout-width),100%) 1fr;
 }
 
-.hero.block a {
+.hero-wrapper .hero.block a {
     text-decoration: none;
 }
 
-.hero.block .hero-container {
+.hero-wrapper .hero.block .hero-container {
     position: relative;
     display: grid;
     grid-template-columns: 1fr min(835px,50%) min(835px,50%) 1fr;
     grid-column: 1/-1;
 }
 
-.hero.block .hero-container::after {
+.hero-wrapper .hero.block .hero-container::after {
     content: "";
     grid-column: 2/4;
     grid-row: 1;
@@ -23,25 +23,25 @@
 }
 
 @media (min-width: 769px) {
-    .hero.block .hero-container::after {
+    .hero-wrapper .hero.block .hero-container::after {
         padding-bottom: 90%;
     }
 }
 
 @media (min-width: 1281px) {
-    .hero.block .hero-container::after {
+    .hero-wrapper .hero.block .hero-container::after {
         padding-bottom: 56%;
     }
 }
 
-.hero.block .hero-image-container {
+.hero-wrapper .hero.block .hero-image-container {
     overflow: hidden;
     position: relative;
     grid-column: 1/-1;
     grid-row: 1;
 }
 
-.hero.block .hero-image-container::after {
+.hero-wrapper .hero.block .hero-image-container::after {
     z-index: 1;
     display: block;
     content: "";
@@ -52,19 +52,19 @@
     height: 100%;
 }
 
-.hero.block.text-right .hero-image-container::after {
+.hero-wrapper .hero.block.text-right .hero-image-container::after {
     background: linear-gradient(to top left,#151517 .22%,rgb(21 21 23 / 0%) 99.99%);
 }
 
-.hero.block.text-center .hero-image-container::after {
+.hero-wrapper .hero.block.text-center .hero-image-container::after {
     background: linear-gradient(0deg,#151517 .22%,rgb(21 21 23 / 0%) 99.99%);
 }
 
-.hero.block.text-left .hero-image-container::after {
+.hero-wrapper .hero.block.text-left .hero-image-container::after {
     background: linear-gradient(to top right,#151517 .22%,rgb(21 21 23 / 0%) 99.99%);
 }
 
-.hero.block .hero-image-container img {
+.hero-wrapper .hero.block .hero-image-container img {
     position: absolute;
     top: 0;
     left: 0;
@@ -74,7 +74,7 @@
     object-position: 50% 10%;
 }
 
-.hero.block .hero-text-container {
+.hero-wrapper .hero.block .hero-text-container {
     display: flex;
     height: 100%;
     grid-row: 1;
@@ -84,32 +84,32 @@
 }
 
 @media (min-width: 769px) {
-    .hero.block .hero-text-container {
+    .hero-wrapper .hero.block .hero-text-container {
         grid-column: 2/4;
         padding: 30px 30px 115px;
     }
 }
 
 @media (min-width: 1281px) {
-    .hero.block .hero-text-container {
+    .hero-wrapper .hero.block .hero-text-container {
         padding: 100px 100px 190px;
     }
 }
 
-.hero.block.text-right .hero-text-container {
+.hero-wrapper .hero.block.text-right .hero-text-container {
     justify-content: flex-end;
 }
 
-.hero.block.text-left .hero-text-container {
+.hero-wrapper .hero.block.text-left .hero-text-container {
     justify-content: flex-start;
 }
 
-.hero.block.text-center .hero-text-container {
+.hero-wrapper .hero.block.text-center .hero-text-container {
     justify-content: center;
     text-align: center;
 }
 
-.hero.block .hero-text-container a {
+.hero-wrapper .hero.block .hero-text-container a {
     padding: 0 18px;
     display: flex;
     flex-direction: column;
@@ -119,18 +119,18 @@
 }
 
 @media (min-width: 769px) {
-    .hero.block .hero-text-container a {
+    .hero-wrapper .hero.block .hero-text-container a {
         width: 70%;
     }
 }
 
 @media (min-width: 1281px) {
-    .hero.block .hero-text-container a {
+    .hero-wrapper .hero.block .hero-text-container a {
         width: 43%;
     }
 }
 
-.hero.block :is(h1, h2) {
+.hero-wrapper .hero.block :is(h1, h2) {
     color: #fff;
     font-family: var(--font-tungsten);
     text-transform: uppercase;
@@ -142,19 +142,19 @@
 }
 
 @media (min-width: 1025px) {
-    .hero.block :is(h1, h2) {
+    .hero-wrapper .hero.block :is(h1, h2) {
         padding-bottom: 15px;
         font-size: 50px;
     }
 }
 
 @media (min-width: 1281px) {
-    .hero.block :is(h1, h2) {
+    .hero-wrapper .hero.block :is(h1, h2) {
         font-size: 67px;
     }
 }
 
-.hero.block :is(h1, h2) + p {
+.hero-wrapper .hero.block :is(h1, h2) + p {
     color: #fff;
     font-family: var(--font-gotham);
     font-weight: 400;
@@ -164,13 +164,13 @@
 }
 
 @media (min-width: 1281px) {
-    .hero.block :is(h1, h2) + p {
+    .hero-wrapper .hero.block :is(h1, h2) + p {
         font-size: 20px;
         padding-bottom: 25px;
     }
 }
 
-.hero.block .hero-text-container .button-container {
+.hero-wrapper .hero.block .hero-text-container .button-container {
     margin-bottom: 25px;
     display: inline-flex;
     align-items: center;
@@ -182,17 +182,17 @@
     text-transform: uppercase;
 }
 
-.hero.block.text-center .hero-text-container .button-container {
+.hero-wrapper .hero.block.text-center .hero-text-container .button-container {
     justify-content: center;
 }
 
 @media (min-width: 769px) {
-    .hero.block .hero-text-container .hero-button-container {
+    .hero-wrapper .hero.block .hero-text-container .hero-button-container {
         font-size: 14px;
     }
 }
 
-.hero.block .hero-text-container .button-container .icon-container {
+.hero-wrapper .hero.block .hero-text-container .button-container .icon-container {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -204,21 +204,21 @@
     transition: background .2s;
 }
 
-.hero.block .hero-text-container .button-container:hover .icon-container {
+.hero-wrapper .hero.block .hero-text-container .button-container:hover .icon-container {
     background: #000;
 }
 
-.hero.block .button-container span {
+.hero-wrapper .hero.block .button-container span {
     font-size: 12px;
 }
 
 @media (min-width: 769px) {
-    .hero.block .button-container span {
+    .hero-wrapper .hero.block .button-container span {
         font-size: 14px;
     }
 }
 
-.hero.block .hero-cards-container {
+.hero-wrapper .hero.block .hero-cards-container {
     padding: 15px 18px;
     width: 100%;
     display: flex;
@@ -231,7 +231,7 @@
 }
 
 @media (min-width: 769px) {
-    .hero.block .hero-cards-container {
+    .hero-wrapper .hero.block .hero-cards-container {
         padding: 15px;
         margin-top: -75px;
         width: 90%;
@@ -240,7 +240,7 @@
 }
 
 @media (min-width: 1281px) {
-    .hero.block .hero-cards-container {
+    .hero-wrapper .hero.block .hero-cards-container {
         padding: 10px 15px;
         margin-top: -110px;
         margin-right: 0;
@@ -250,24 +250,24 @@
     }
 }
 
-.hero.block .hero-cards-container a {
+.hero-wrapper .hero.block .hero-cards-container a {
     display: flex;
     margin-bottom: 15px;
 }
 
 @media (min-width: 1281px) {
-    .hero.block .hero-cards-container a {
+    .hero-wrapper .hero.block .hero-cards-container a {
         width: 33.33%;
     }
 }
 
 @media (min-width: 1281px) {
-    .hero.block .hero-cards-container a {
+    .hero-wrapper .hero.block .hero-cards-container a {
         margin-bottom: 0;
     }
 }
 
-.hero.block .hero-cards-container picture {
+.hero-wrapper .hero.block .hero-cards-container picture {
     display: block;
     overflow: hidden;
     flex-shrink: 0;
@@ -276,7 +276,7 @@
     height: 120px;
 }
 
-.hero.block .hero-cards-container img {
+.hero-wrapper .hero.block .hero-cards-container img {
     position: absolute;
     object-fit: cover;
     object-position: center 30%;
@@ -285,15 +285,15 @@
     transition: transform 3s;
 }
 
-.hero.block.columns .hero-image-container img {
+.hero-wrapper .hero.block.columns .hero-image-container img {
     transition: transform 3s;
 }
 
-.hero.block .hero-cards-container a:hover img {
+.hero-wrapper .hero.block .hero-cards-container a:hover img {
     transform: scale(1.2);
 }
 
-.hero.block .hero-cards-container a div {
+.hero-wrapper .hero.block .hero-cards-container a div {
     display: block;
     position: relative;
     width: 100%;
@@ -301,12 +301,12 @@
 }
 
 @media (min-width: 1281px) {
-    .hero.block .hero-cards-container a div {
+    .hero-wrapper .hero.block .hero-cards-container a div {
         padding: 0 15px 24px;
     }
 }
 
-.hero.block .hero-cards-container a span {
+.hero-wrapper .hero.block .hero-cards-container a span {
     color: #adb4b7;
     text-transform: uppercase;
     font-weight: 500;
@@ -316,7 +316,7 @@
     margin-bottom: 10px;
 }
 
-.hero.block .hero-cards-container a .hero-card-title {
+.hero-wrapper .hero.block .hero-cards-container a .hero-card-title {
     display: block;
     color: #151517;
     font-family: var(--font-gotham);
@@ -328,13 +328,13 @@
 }
 
 @media (max-width: 768px) {
-    .hero.block .hero-cards-container a .hero-card-title {
+    .hero-wrapper .hero.block .hero-cards-container a .hero-card-title {
         font-size: 14px;
     }
 }
 
 /* hero columns variant */
-.hero.block.columns .hero-text-container {
+.hero-wrapper .hero.block.columns .hero-text-container {
     grid-row: 2;
     padding-bottom: 65px;
     padding-top: 20px;
@@ -342,115 +342,115 @@
     justify-content: flex-end;
 }
 
-.hero.block.columns .hero-container::after {
+.hero-wrapper .hero.block.columns .hero-container::after {
     padding-bottom: 80%;
 }
 
 @media (min-width: 769px) {
-    .hero.block.columns .hero-container::after {
+    .hero-wrapper .hero.block.columns .hero-container::after {
         padding-bottom: 46%;
     }
 }
 
 @media (min-width: 769px) {
-    .hero.block.columns .hero-text-container {
+    .hero-wrapper .hero.block.columns .hero-text-container {
         padding: 30px;
         grid-row: 1;
     }
 
-    .hero.block.columns.text-left .hero-text-container {
+    .hero-wrapper .hero.block.columns.text-left .hero-text-container {
         grid-column: 1/3;
     }
 
-    .hero.block.columns.text-right .hero-text-container {
+    .hero-wrapper .hero.block.columns.text-right .hero-text-container {
         grid-column: 3/-1;
     }
 }
 
 @media (min-width: 1281px) {
-    .hero.block.columns .hero-text-container {
+    .hero-wrapper .hero.block.columns .hero-text-container {
         padding: 100px;
     }
 }
 
 @media (min-width: 769px) {
-    .hero.block.columns.with-cards .hero-text-container {
+    .hero-wrapper .hero.block.columns.with-cards .hero-text-container {
         padding-bottom: 115px;
     }
 }
 
 @media (min-width: 1281px) {
-    .hero.block.columns.with-cards .hero-text-container {
+    .hero-wrapper .hero.block.columns.with-cards .hero-text-container {
         padding-bottom: 190px;
     }
 }
 
-.hero.block.columns .hero-text-container a {
+.hero-wrapper .hero.block.columns .hero-text-container a {
     width: 100%;
 }
 
-.hero.block.columns :is(h1, h2) {
+.hero-wrapper .hero.block.columns :is(h1, h2) {
     padding-bottom: 10px;
 }
 
-.hero.block.columns :is(h1, h2) + p {
+.hero-wrapper .hero.block.columns :is(h1, h2) + p {
     padding-bottom: 20px;
 }
 
-.hero.block.columns :is(h1, h2),
-.hero.block.columns :is(h1, h2) + p,
-.hero.block.columns .hero-text-container .button-container {
+.hero-wrapper .hero.block.columns :is(h1, h2),
+.hero-wrapper .hero.block.columns :is(h1, h2) + p,
+.hero-wrapper .hero.block.columns .hero-text-container .button-container {
     color: #151517;
     margin: 0;
 }
 
 @media (min-width: 1281px) {
-    .hero.block.columns :is(h1, h2) + p {
+    .hero-wrapper .hero.block.columns :is(h1, h2) + p {
         font-size: 16px;
         padding-bottom: 25px;
     }
 }
 
 @media (min-width: 769px) {
-    .hero.block.columns .hero-image-container {
+    .hero-wrapper .hero.block.columns .hero-image-container {
         grid-row: 1;
     }
 
-    .hero.block.columns.text-left .hero-image-container {
+    .hero-wrapper .hero.block.columns.text-left .hero-image-container {
         grid-column: 3/-1;
     }
 
-    .hero.block.columns.text-right .hero-image-container {
+    .hero-wrapper .hero.block.columns.text-right .hero-image-container {
         grid-column: 1/3;
     }
 }
 
-.hero.block.columns .hero-image-container::after {
+.hero-wrapper .hero.block.columns .hero-image-container::after {
     display: none;
 }
 
-.hero.block.columns:hover .hero-image-container img {
+.hero-wrapper .hero.block.columns:hover .hero-image-container img {
     transform: scale(1.1);
 }
 
 /* Hero dark */
-.dark .hero.block .hero-text-container {
+.dark .hero-wrapper .hero.block .hero-text-container {
     background-color: #151517;
     color: #fff;
 }
 
-.dark .hero.block .hero-text-container a {
+.dark .hero-wrapper .hero.block .hero-text-container a {
     justify-content: center;
 }
 
-.dark .hero.block .hero-text-container :is(h1, h2, p, a, span) {
+.dark .hero-wrapper .hero.block .hero-text-container :is(h1, h2, p, a, span) {
     color: #fff;
 }
 
-.dark .hero.block .hero-container {
+.dark .hero-wrapper .hero.block .hero-container {
     margin-top: 90px;
 }
 
-.dark .hero.block.columns .hero-container {
+.dark .hero-wrapper .hero.block.columns .hero-container {
     margin-top: 0;
 }

--- a/blocks/long-form/long-form.css
+++ b/blocks/long-form/long-form.css
@@ -1,66 +1,66 @@
-.long-form.block .container {
+.long-form-wrapper .long-form.block .container {
     margin: 0 auto;
 }
 
-.long-form.block .container-article {
+.long-form-wrapper .long-form.block .container-article {
     margin-bottom: 30px;
 }
 
-.long-form.block .article-content {
+.long-form-wrapper .long-form.block .article-content {
     color: #000;
     background-color: #fff;
     transition: background-color .75s,color .75s;
     margin-bottom: 30px;
 }
 
-.long-form.block .article-content.dark {
+.long-form-wrapper .long-form.block .article-content.dark {
     color: #fff;
     background: #151517;
 }
 
-.long-form.block .attribution a {
+.long-form-wrapper .long-form.block .attribution a {
     color: inherit;
     text-decoration: none;
 }
 
-.long-form.block .article-body a {
+.long-form-wrapper .long-form.block .article-body a {
     color: #000;
     text-decoration: none;
 }
 
-.long-form.block .article-body strong > a {
+.long-form-wrapper .long-form.block .article-body strong > a {
     text-decoration: underline;
 }
 
-.long-form.block .article-body p em > a {
+.long-form-wrapper .long-form.block .article-body p em > a {
     font-weight: 500;
     text-decoration: underline;
 }
 
-.long-form.block .article-content.dark a {
+.long-form-wrapper .long-form.block .article-content.dark a {
     color: white;
 }
 
-.long-form.block .lead {
+.long-form-wrapper .long-form.block .lead {
     display: flex;
     flex-direction: column-reverse;
     position: relative;
 }
 
 @media (min-width: 1025px) {
-    .long-form.block .lead {
+    .long-form-wrapper .long-form.block .lead {
         display: grid;
         grid-template-rows: 750px auto;
         grid-template-columns: 1fr min(230px,10%) min(400px,40%) min(400px,40%) min(230px,10%) 1fr;
     }
 }
 
-.long-form.block .headline {
+.long-form-wrapper .long-form.block .headline {
     padding: 15px;
 }
 
 @media (min-width: 1025px) {
-    .long-form.block .headline {
+    .long-form-wrapper .long-form.block .headline {
         display: flex;
         flex-direction: column;
         align-items: center;
@@ -74,7 +74,7 @@
     }
 }
 
-.long-form.block .headline .rubric {
+.long-form-wrapper .long-form.block .headline .rubric {
     font-size: 12px;
     margin-bottom: 20px;
     display: block;
@@ -85,13 +85,13 @@
 }
 
 @media (min-width: 769px) {
-    .long-form.block .headline .rubric {
+    .long-form-wrapper .long-form.block .headline .rubric {
         font-size: 13px;
         line-height: 12.44px;
     }
 }
 
-.long-form.block .headline h1 {
+.long-form-wrapper .long-form.block .headline h1 {
     font-style: normal;
     font-weight: 700;
     letter-spacing: .05em;
@@ -100,7 +100,7 @@
 }
 
 @media (min-width: 1025px) {
-    .long-form.block .headline h1 {
+    .long-form-wrapper .long-form.block .headline h1 {
         text-align: center;
         margin-top: 0;
         margin-bottom: 20px;
@@ -108,20 +108,20 @@
     }
 }
 
-.long-form.block .headline .description {
+.long-form-wrapper .long-form.block .headline .description {
     font-weight: 400;
     color: inherit;
     display: block;
     margin: 20px 0;
 }
 
-.long-form.block .article-body div > p {
+.long-form-wrapper .long-form.block .article-body div > p {
     line-height: 30px;
     margin-bottom: 20px;
     padding: 0 20px;
 }
 
-.long-form.block .article-body h2 {
+.long-form-wrapper .long-form.block .article-body h2 {
     font-family: var(--font-tungsten);
     font-size: 37px;
     font-style: normal;
@@ -135,36 +135,36 @@
     text-align: center;
 }
 
-.long-form.block .article-body div > h2 {
+.long-form-wrapper .long-form.block .article-body div > h2 {
     margin-top: 0;
     margin-bottom: 20px;
     padding: 0 20px;
 }
 
 @media (min-width: 1025px) {
-    .long-form.block .article-body div > p {
+    .long-form-wrapper .long-form.block .article-body div > p {
         padding: 0 35px;
         margin-bottom: 60px;
     }
 
-    .long-form.block .article-body div > h2 {
+    .long-form-wrapper .long-form.block .article-body div > h2 {
         margin-top: 0;
         margin-bottom: 60px;
     }
 }
 
-.long-form.block .headline .description p {
+.long-form-wrapper .long-form.block .headline .description p {
     margin: 0;
 }
 
 @media (min-width: 769px) {
-    .long-form.block .headline .description {
+    .long-form-wrapper .long-form.block .headline .description {
         font-size: 18px;
         line-height: 30px;
     }
 }
 
-.long-form.block .lead > .byline {
+.long-form-wrapper .long-form.block .lead > .byline {
     display: flex;
     padding-top: 60px;
     grid-column: 1/3;
@@ -177,30 +177,30 @@
     text-align: right;
 }
 
-.long-form.block .headline .byline {
+.long-form-wrapper .long-form.block .headline .byline {
     display: flex;
     align-items: center;
 }
 
 @media (min-width: 1025px) {
-    .long-form.block .headline .byline {
+    .long-form-wrapper .long-form.block .headline .byline {
         display: none;
     }
 }
 
 @media (max-width: 1024px) {
-    .long-form.block .lead > .byline {
+    .long-form-wrapper .long-form.block .lead > .byline {
         display: none;
     }
 }
 
-.long-form.block .lead .image {
+.long-form-wrapper .long-form.block .lead .image {
     grid-column: 1/-1;
     grid-row: 1;
     height: 100%;
 }
 
-.long-form.block .lead picture {
+.long-form-wrapper .long-form.block .lead picture {
     display: block;
     height: 100%;
     width: 100%;
@@ -211,7 +211,7 @@
     position: relative;
 }
 
-.long-form.block .lead picture::after {
+.long-form-wrapper .long-form.block .lead picture::after {
     background: linear-gradient(.01deg,#151517 .22%,rgb(21 21 23 / 0%) 70%);
     z-index: 1;
     display: block;
@@ -224,19 +224,19 @@
 }
 
 @media (min-width: 1025px) {
-    .long-form.block .lead picture {
+    .long-form-wrapper .long-form.block .lead picture {
         position: absolute;
     }
 }
 
-.long-form.block .lead img {
+.long-form-wrapper .long-form.block .lead img {
     object-position: 50% 10%;
     height: 100%;
     width: 100%;
     object-fit: cover;
 }
 
-.long-form.block .attribution {
+.long-form-wrapper .long-form.block .attribution {
     font-style: normal;
     font-weight: 700;
     letter-spacing: 0;
@@ -247,29 +247,29 @@
 }
 
 @media (min-width: 769px) {
-    .long-form.block .attribution {
+    .long-form-wrapper .long-form.block .attribution {
         font-size: 16px;
         line-height: 22px;
     }
 }
 
 @media (max-width: 1025px) {
-    .long-form.block .attribution {
+    .long-form-wrapper .long-form.block .attribution {
         display: flex;
         align-items: center;
         margin-bottom: 0;
     }
 
-    .long-form.block .headline > .byline {
+    .long-form-wrapper .long-form.block .headline > .byline {
         margin-bottom: 45px;
     }
 }
 
-.long-form.block .attribution a:hover {
+.long-form-wrapper .long-form.block .attribution a:hover {
     text-decoration: underline;
 }
 
-.long-form.block .publication {
+.long-form-wrapper .long-form.block .publication {
     color: #adb4b7;
     font-size: 14px;
     font-weight: 700;
@@ -278,65 +278,65 @@
 }
 
 @media (min-width: 1025px) {
-    .long-form.block .publication {
+    .long-form-wrapper .long-form.block .publication {
         margin-bottom: 42px;
     }
 }
 
-.long-form.block .publication .separator {
+.long-form-wrapper .long-form.block .publication .separator {
     display: block;
     border-left: 1px solid #e6e6e6;
     height: 0.8em;
     margin: 0 10px;
 }
 
-.long-form.block .byline .social-share .label {
+.long-form-wrapper .long-form.block .byline .social-share .label {
     display: none;
 }
 
-.long-form.block .lead > .byline .social-share .columns {
+.long-form-wrapper .long-form.block .lead > .byline .social-share .columns {
     flex-wrap: wrap;
     justify-content: flex-end;
 }
 
-.long-form.block .byline .credit {
+.long-form-wrapper .long-form.block .byline .credit {
     font-size: 12px;
     font-style: italic;
     line-height: 16px;
     color: #9a9a9a;
 }
 
-.long-form.block .article-body {
+.long-form-wrapper .long-form.block .article-body {
     max-width: 800px;
     margin: auto;
     padding-bottom: 60px;
 }
 
 @media (min-width: 1025px) {
-    .long-form.block .article-body {
+    .long-form-wrapper .long-form.block .article-body {
         padding-top: 60px;
     }
 }
 
-.long-form.block .article-body hr {
+.long-form-wrapper .long-form.block .article-body hr {
     margin: 0 35px 60px;
 }
 
-.long-form.block .article-body div > p.highlight {
+.long-form-wrapper .long-form.block .article-body div > p.highlight {
     font-size: 18px;
     margin-top: 0;
 }
 
-.long-form.block .article-body img {
+.long-form-wrapper .long-form.block .article-body img {
     width: 100%;
     height: auto;
 }
 
-.long-form.block .article-body a:hover {
+.long-form-wrapper .long-form.block .article-body a:hover {
     color: var(--link-hover-color);
 }
 
-.long-form.block .article-body .photo-credit {
+.long-form-wrapper .long-form.block .article-body .photo-credit {
     border-bottom: 1px solid #c4c4c4;
     max-width: 635px;
     font-size: 12px;
@@ -347,16 +347,16 @@
 }
 
 @media (min-width: 1025px) {
-    .long-form.block .article-body .photo-credit {
+    .long-form-wrapper .long-form.block .article-body .photo-credit {
         margin-bottom: 60px;
     }
 }
 
-.long-form.block .article-body .fullscreen {
+.long-form-wrapper .long-form.block .article-body .fullscreen {
     margin-bottom: 0;
 }
 
-.long-form.block .article-body .fullscreen img {
+.long-form-wrapper .long-form.block .article-body .fullscreen img {
     position: relative;
     background-color: #ededed;
     width: 100vw;

--- a/blocks/newsletter-subscribe/newsletter-subscribe.css
+++ b/blocks/newsletter-subscribe/newsletter-subscribe.css
@@ -1,4 +1,4 @@
-.newsletter-subscribe.block {
+.newsletter-subscribe-wrapper .newsletter-subscribe.block {
   padding: 0 39px;
   max-width: 1440px;
   margin: 0 auto;
@@ -6,21 +6,21 @@
   --circle-svg: url("data:image/svg+xml,%3Csvg%20viewBox%3D%220%200%20100%20100%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Ccircle%20fill%3D%22%23fff%22%20cx%3D%2250%22%20cy%3D%2250%22%20r%3D%2250%22%20%2F%3E%3C%2Fsvg%3E");
 }
 
-.newsletter-subscribe.block .subscribe-form {
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form {
   display: flex;
   flex-direction: column;
   gap: 30px;
 }
 
-.newsletter-subscribe.block .subscribe-form a:hover {
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form a:hover {
   color: inherit;
 }
 
-.newsletter-subscribe.block .subscribe-form label[for*="checkbox"] {
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form label[for*="checkbox"] {
   cursor: pointer;
 }
 
-.newsletter-subscribe.block .subscribe-form input.toggle {
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form input.toggle {
   cursor: pointer;
   width: 51px;
   height: 30px;
@@ -34,23 +34,23 @@
   transition: background 0.4s ease;
 }
 
-.newsletter-subscribe.block .subscribe-form input.toggle:checked {
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form input.toggle:checked {
   background: var(--circle-svg), #1f2022;
   background-size: 22px 22px;
   background-repeat: no-repeat;
   background-position: 26px 4px;
 }
 
-.newsletter-subscribe.block .subscribe-form .title-wrapper {
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .title-wrapper {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
 }
 
-.newsletter-subscribe.block .subscribe-form .title-wrapper h1,
-.newsletter-subscribe.block .subscribe-form .title-wrapper h2,
-.newsletter-subscribe.block .subscribe-form .title-wrapper h3 {
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .title-wrapper h1,
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .title-wrapper h2,
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .title-wrapper h3 {
   font-family: var(--font-tungsten);
   font-size: 67px;
   font-weight: 600;
@@ -61,7 +61,7 @@
   margin: 0 0 10px;
 }
 
-.newsletter-subscribe.block .subscribe-form .title-wrapper [slot="description"] p {
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .title-wrapper [slot="description"] p {
   font-family: var(--font-gotham);
   text-align: center;
   max-width: 500px;
@@ -73,7 +73,7 @@
   line-height: 30px;
 }
 
-.newsletter-subscribe.block .subscribe-form .title-wrapper [slot="tos-top"] {
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .title-wrapper [slot="tos-top"] {
   color: #1f2022;
   text-align: center;
   font-family: var(--font-gotham);
@@ -83,24 +83,24 @@
   margin-bottom: 20px;
 }
 
-.newsletter-subscribe.block .subscribe-form .title-wrapper [slot="tos-top"] a {
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .title-wrapper [slot="tos-top"] a {
   font-weight: bold;
 }
 
-.newsletter-subscribe.block .subscribe-form .title-wrapper [slot="tos-top"] p {
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .title-wrapper [slot="tos-top"] p {
   margin: 0;
 }
 
-.newsletter-subscribe.block .subscribe-form .title-wrapper [slot="description"] p:first-child {
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .title-wrapper [slot="description"] p:first-child {
   line-height: 135%;
   color: #151517;
 }
 
-.newsletter-subscribe.block .subscribe-form .title-wrapper [slot="description"] p:last-child {
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .title-wrapper [slot="description"] p:last-child {
   margin-bottom: 30px;
 }
 
-.newsletter-subscribe.block .subscribe-form .controls-wrapper {
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .controls-wrapper {
   width: 100%;
   max-width: 600px;
   margin: 0 auto;
@@ -109,7 +109,7 @@
   gap: 30px;
 }
 
-.newsletter-subscribe.block .subscribe-form .controls-wrapper .email-input {
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .controls-wrapper .email-input {
   height: 70px;
   width: 100%;
   border: 1px solid #adb4b7;
@@ -125,31 +125,31 @@
   font-family: var(--font-gotham);
 }
 
-.newsletter-subscribe.block .subscribe-form .controls-wrapper .email-input:focus {
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .controls-wrapper .email-input:focus {
   border: 1px solid #87b9ea;
   outline: none;
   box-shadow: 0 0 5px 0 #1d87ff;
 }
 
-.newsletter-subscribe.block .subscribe-form .controls-wrapper .email-input::placeholder {
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .controls-wrapper .email-input::placeholder {
   color: #adb4b7;
 }
 
-.newsletter-subscribe.block .subscribe-form .controls-wrapper .email-input.invalid {
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .controls-wrapper .email-input.invalid {
   border-style: solid;
   border-width: 1px;
   border-color: #e76468;
   box-shadow: none;
 }
 
-.newsletter-subscribe.block .subscribe-form .controls-wrapper .email-input.valid {
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .controls-wrapper .email-input.valid {
   background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAMAAAAolt3jAAAApVBMVEUAAAAAc5kAbZ4AdKIGcJ8GcJ4Gb58GcZ4GcJ8GcZ4GcJ4FcJ4Fb54FcJ4FcJ4FcJ4FcJ4FcJ4FcJ4FcJ4FcJ4FcJ4NdKEQdqIUeKQWeqQcfacdfacggKkmg6s3jbE5jrJHlrdJl7hWn75aoL9hpcJurMdyrsiEuc+YxNeiytujytuy0+Hc6/Hi7vTl8PXp8/fq8/fy+Pr6/P39/v7+/v7+/v////9mbyKVAAAAFXRSTlMAFBUWUlRVgYKDhM3Oz9Dw8fLz9P7FJ1F0AAAAAWJLR0Q2R7+I0QAAAIZJREFUCB0twQcWgjAARMFVQERRCPLtDXvv5v5HMw+ckeO1Or1eHHkqNQwlE8hp5PzlgeQZKrMNaV0tKoOLndJUl8rBniFWBn1g+X2MwciweO0ZXu0KSNVhcre7kz3ixIpg/vzY2wgnlGegeNsCJ6lJQQ7rLU7uywlSSomvUr3ZzrJ2WJP0AxPADxwFmQlQAAAAAElFTkSuQmCC");
   background-position: right 5px center;
   background-repeat: no-repeat;
   padding-right: 25px;
 }
 
-.newsletter-subscribe.block .subscribe-form .controls-wrapper .invalid-email-text {
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .controls-wrapper .invalid-email-text {
   display: none;
   height: 23px;
   font-size: 13px;
@@ -161,11 +161,11 @@
   text-align: center;
 }
 
-.newsletter-subscribe.block .subscribe-form .controls-wrapper .email-input.invalid + .invalid-email-text {
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .controls-wrapper .email-input.invalid + .invalid-email-text {
   display: block;
 }
 
-.newsletter-subscribe.block .subscribe-form .subscribe-to-all-wrapper {
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .subscribe-to-all-wrapper {
   max-width: 550px;
   width: 100%;
   margin: 0 auto 60px;
@@ -175,7 +175,7 @@
   align-items: flex-start;
 }
 
-.newsletter-subscribe.block .subscribe-form .subscribe-to-all-wrapper .toggle-label {
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .subscribe-to-all-wrapper .toggle-label {
   text-transform: uppercase;
   font-size: 14px;
   font-weight: bold;
@@ -186,7 +186,7 @@
   font-family: var(--font-gotham);
 }
 
-.newsletter-subscribe.block .subscribe-form .subscribe-list {
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .subscribe-list {
   padding: 0;
   margin: 0;
   list-style: none;
@@ -195,7 +195,7 @@
   gap: 30px;
 }
 
-.newsletter-subscribe.block .subscribe-form .subscribe-list .subscribe-item {
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .subscribe-list .subscribe-item {
   display: flex;
   background-color: #fff;
   gap: 25px;
@@ -203,7 +203,7 @@
   height: 203px;
 }
 
-.newsletter-subscribe.block .subscribe-form .subscribe-list .subscribe-item .image-wrapper {
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .subscribe-list .subscribe-item .image-wrapper {
   width: 285px;
   height: 203px;
   min-width: 285px;
@@ -211,21 +211,21 @@
   overflow: hidden;
 }
 
-.newsletter-subscribe.block .subscribe-form .subscribe-list .subscribe-item .image-wrapper picture,
-.newsletter-subscribe.block .subscribe-form .subscribe-list .subscribe-item .image-wrapper img {
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .subscribe-list .subscribe-item .image-wrapper picture,
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .subscribe-list .subscribe-item .image-wrapper img {
   width: 100%;
   height: 100%;
   object-fit: cover;
 }
 
-.newsletter-subscribe.block .subscribe-form .subscribe-list .subscribe-item .text-wrapper {
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .subscribe-list .subscribe-item .text-wrapper {
   display: flex;
   flex-direction: column;
   gap: 12px;
   margin: 25px 0 5px;
 }
 
-.newsletter-subscribe.block .subscribe-form .subscribe-list .subscribe-item .text-wrapper .item-title {
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .subscribe-list .subscribe-item .text-wrapper .item-title {
   font-family: var(--font-tungsten);
   font-size: 42px;
   font-weight: 400;
@@ -237,7 +237,7 @@
   height: 44px;
 }
 
-.newsletter-subscribe.block .subscribe-form .subscribe-list .subscribe-item .text-wrapper p {
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .subscribe-list .subscribe-item .text-wrapper p {
   margin: 0;
   font-size: 14px;
   font-weight: 325;
@@ -248,19 +248,19 @@
   font-family: var(--font-gotham);
 }
 
-.newsletter-subscribe.block .subscribe-form .subscribe-list .subscribe-item .checkbox-wrapper {
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .subscribe-list .subscribe-item .checkbox-wrapper {
   margin-top: 33px;
   margin-left: auto;
 }
 
-.newsletter-subscribe.block .subscribe-form .form-footer {
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .form-footer {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
 }
 
-.newsletter-subscribe.block .subscribe-form .form-footer .sign-up-button {
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .form-footer .sign-up-button {
   padding: 0;
   border: none;
   color: white;
@@ -281,12 +281,12 @@
   margin-bottom: 10px;
 }
 
-.newsletter-subscribe.block .subscribe-form .form-footer .sign-up-button:hover {
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .form-footer .sign-up-button:hover {
   background-color: #000;
 }
 
-.newsletter-subscribe.block .subscribe-form .form-footer [slot="footer-privacy"],
-.newsletter-subscribe.block .subscribe-form .form-footer [slot="footer-tos-links"] {
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .form-footer [slot="footer-privacy"],
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .form-footer [slot="footer-tos-links"] {
   color: #1f2022;
   text-align: center;
   font-family: var(--font-gotham);
@@ -296,76 +296,76 @@
   letter-spacing: 0;
 }
 
-.newsletter-subscribe.block .subscribe-form .form-footer [slot="footer-privacy"] a,
-.newsletter-subscribe.block .subscribe-form .form-footer [slot="footer-tos-links"] a {
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .form-footer [slot="footer-privacy"] a,
+.newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .form-footer [slot="footer-tos-links"] a {
   font-weight: bold;
 }
 
 @media (max-width: 768px) {
-  .newsletter-subscribe.block .subscribe-form .title-wrapper h1,
-  .newsletter-subscribe.block .subscribe-form .title-wrapper h2,
-  .newsletter-subscribe.block .subscribe-form .title-wrapper h3 {
+  .newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .title-wrapper h1,
+  .newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .title-wrapper h2,
+  .newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .title-wrapper h3 {
     font-size: 50px;
     line-height: 52px;
   }
 
-  .newsletter-subscribe.block .subscribe-form .subscribe-list .subscribe-item .text-wrapper .item-title {
+  .newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .subscribe-list .subscribe-item .text-wrapper .item-title {
     font-size: 36px;
   }
 }
 
 @media (max-width: 700px) {
-  .newsletter-subscribe.block .subscribe-form .subscribe-list .subscribe-item .text-wrapper .item-title {
+  .newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .subscribe-list .subscribe-item .text-wrapper .item-title {
     font-size: 32px;
   }
 }
 
 @media (max-width: 600px) {
-  .newsletter-subscribe.block .subscribe-form .subscribe-list .subscribe-item .image-wrapper {
+  .newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .subscribe-list .subscribe-item .image-wrapper {
     width: 115px;
     height: 115px;
     min-width: 115px;
     min-height: 115px;
   }
 
-  .newsletter-subscribe.block .subscribe-form .subscribe-list .subscribe-item {
+  .newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .subscribe-list .subscribe-item {
     height: 115px;
     padding-right: 12px;
     gap: 14px;
   }
 
-  .newsletter-subscribe.block .subscribe-form .subscribe-list .subscribe-item .text-wrapper {
+  .newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .subscribe-list .subscribe-item .text-wrapper {
     margin-top: 10px;
     gap: 0;
   }
 
-  .newsletter-subscribe.block .subscribe-form .subscribe-list .subscribe-item .text-wrapper .item-title {
+  .newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .subscribe-list .subscribe-item .text-wrapper .item-title {
     height: 38px;
     font-size: 28px;
     line-height: 38px;
   }
 
-  .newsletter-subscribe.block .subscribe-form .subscribe-list .subscribe-item .checkbox-wrapper {
+  .newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .subscribe-list .subscribe-item .checkbox-wrapper {
     margin-top: 14px;
     margin-left: auto;
   }
 
-  .newsletter-subscribe.block .subscribe-form .form-footer .sign-up-button {
+  .newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .form-footer .sign-up-button {
     font-size: 12px;
   }
 }
 
 @media (max-width: 500px) {
-  .newsletter-subscribe.block .subscribe-form .controls-wrapper .email-input {
+  .newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .controls-wrapper .email-input {
     height: 36px;
     font-size: 13px;
   }
 
-  .newsletter-subscribe.block .subscribe-form .subscribe-list .subscribe-item .text-wrapper p {
+  .newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .subscribe-list .subscribe-item .text-wrapper p {
     font-size: 13px;
   }
   
-  .newsletter-subscribe.block .subscribe-form .subscribe-list .subscribe-item .text-wrapper .item-title {
+  .newsletter-subscribe-wrapper .newsletter-subscribe.block .subscribe-form .subscribe-list .subscribe-item .text-wrapper .item-title {
     font-size: 20px;
   }
 }

--- a/blocks/open-article/open-article.css
+++ b/blocks/open-article/open-article.css
@@ -2,7 +2,7 @@
   padding: 60px 20px;
 }
 
-.open-article.block h1 {
+.open-article-wrapper .open-article.block h1 {
   font-size: 40px;
   font-family: var(--font-gotham);
   font-style: normal;
@@ -12,12 +12,12 @@
   margin: 20px 0;
 }
 
-.open-article.block {
+.open-article-wrapper .open-article.block {
   max-width: 900px;
   margin: 0 auto;
 }
 
-.open-article.block .article-body p {
+.open-article-wrapper .open-article.block .article-body p {
   font-family: var(--font-gotham);
   font-size: 16px;
   font-style: normal;
@@ -28,7 +28,7 @@
   margin: 0 0 30px;
 }
 
-.open-article.block .article-body p::first-letter {
+.open-article-wrapper .open-article.block .article-body p::first-letter {
   font-weight: 700;
   line-height: 100%;
   letter-spacing: 0;
@@ -38,25 +38,25 @@
 }
 
 @media (min-width: 769px) {
-  .open-article.block .article-body p::first-letter {
+  .open-article-wrapper .open-article.block .article-body p::first-letter {
     font-size: 150px;
     line-height: 85%;
   }
 }
 
-.open-article.block .lead {
+.open-article-wrapper .open-article.block .lead {
   overflow: hidden;
   margin-bottom: 20px;
   vertical-align: baseline;
 }
 
-.open-article.block .lead img {
+.open-article-wrapper .open-article.block .lead img {
   width: auto;
   height: auto;
   max-width: 100%;
 }
 
-.open-article.block .byline {
+.open-article-wrapper .open-article.block .byline {
   display: flex;
   color: black;
   font-family: var(--font-gotham);
@@ -68,17 +68,17 @@
   height: 73px;
 }
 
-.open-article.block .byline .attribution * {
+.open-article-wrapper .open-article.block .byline .attribution * {
   color: black;
   text-decoration: none;
 }
 
-.open-article.block .byline .publication {
+.open-article-wrapper .open-article.block .byline .publication {
   display: flex;
   font-weight: 400;
 }
 
-.open-article.block .byline .publication::before {
+.open-article-wrapper .open-article.block .byline .publication::before {
   content: "";
   display: block;
   border-left: 2px solid #e6e6e6;
@@ -87,7 +87,7 @@
   margin: 0 5px;
 }
 
-.open-article.block .article-body .photo-credit {
+.open-article-wrapper .open-article.block .article-body .photo-credit {
   font-size: 12px;
   line-height: 16px;
   color: #adb4b7;
@@ -95,16 +95,16 @@
   margin-bottom: 50px;
 }
 
-.open-article.block .article-body img {
+.open-article-wrapper .open-article.block .article-body img {
   width: 100%;
   height: auto;
 }
 
-.open-article.block .article-body .portrait {
+.open-article-wrapper .open-article.block .article-body .portrait {
   display: flex;
   justify-content: center;
 }
 
-.open-article.block .article-body .portrait img {
+.open-article-wrapper .open-article.block .article-body .portrait img {
   max-width: 600px;
 }

--- a/blocks/product-listing/product-listing.css
+++ b/blocks/product-listing/product-listing.css
@@ -1,60 +1,60 @@
-.product-listing.block {
+.product-listing-wrapper .product-listing.block {
     background-color: #f6f6f6;
 }
 
-.product-listing.block .container {
+.product-listing-wrapper .product-listing.block .container {
     max-width: var(--layout-width);
     margin: 0 auto;
     padding: 30px 0;
 }
 
-.product-listing.block .article-content {
+.product-listing-wrapper .product-listing.block .article-content {
     display: flex;
     margin-bottom: 80px;
     background-color: white;
     flex-wrap: wrap;
 }
 
-.product-listing.block .article-content .content {
+.product-listing-wrapper .product-listing.block .article-content .content {
     margin-top: 40px;
     margin-left: 5%;
     width: 45%;
 }
 
 @media (max-width: 1649px) {
-    .product-listing.block .article-content .content {
+    .product-listing-wrapper .product-listing.block .article-content .content {
         margin-left: 7.5%;
         width: 42.5%;
     }
 }
 
 @media (max-width: 768px) {
-    .product-listing.block .article-content .content {
+    .product-listing-wrapper .product-listing.block .article-content .content {
         padding: 32px 18px 0;
     }
 }
 
 @media (max-width: 1280px) {
-    .product-listing.block .article-content .content {
+    .product-listing-wrapper .product-listing.block .article-content .content {
         width: 100%;
         margin: 0;
     }
 }
 
-.product-listing.block .article-content picture {
+.product-listing-wrapper .product-listing.block .article-content picture {
     width: 50%;
     display: flex;
 }
 
 @media (max-width: 1280px) {
-    .product-listing.block .article-content picture {
+    .product-listing-wrapper .product-listing.block .article-content picture {
         width: 100%;
         margin-bottom: 30px;
         border-bottom: 1px solid #e6e6e6;
     }
 }
 
-.product-listing.block .article-content h1 {
+.product-listing-wrapper .product-listing.block .article-content h1 {
     font-weight: 400;
     margin-bottom: 20px;
     margin-top: 0;
@@ -64,7 +64,7 @@
     font-size: 2.25em;
 }
 
-.product-listing.block .article-content .brand {
+.product-listing-wrapper .product-listing.block .article-content .brand {
     font-weight: 600;
     margin-bottom: 5px;
     margin-top: 0;
@@ -74,12 +74,12 @@
     font-size: 2.25em;
 }
 
-.product-listing.block .article-content .awards {
+.product-listing-wrapper .product-listing.block .article-content .awards {
     display: flex;
     margin-bottom: 25px;
 }
 
-.product-listing.block .article-content .description {
+.product-listing-wrapper .product-listing.block .article-content .description {
     padding-bottom: 18px;
     margin-bottom: 30px;
     border-bottom: 1px solid #e6e6e6;
@@ -87,31 +87,31 @@
 }
 
 @media (max-width: 1280px) {
-    .product-listing.block .article-content .description {
+    .product-listing-wrapper .product-listing.block .article-content .description {
         border-bottom: 0;
         padding-bottom: 0;
     }
 }
 
-.product-listing.block .article-content .description p:last-of-type {
+.product-listing-wrapper .product-listing.block .article-content .description p:last-of-type {
     margin: 0;
 }
 
-.product-listing.block .article-content .details {
+.product-listing-wrapper .product-listing.block .article-content .details {
     margin-bottom: 20px;
 }
 
-.product-listing.block .article-content .details .separator,
-.product-listing.block .article-content .details .separator + span {
+.product-listing-wrapper .product-listing.block .article-content .details .separator,
+.product-listing-wrapper .product-listing.block .article-content .details .separator + span {
     color: #adb4b7;
 }
 
-.product-listing.block .article-content .link {
+.product-listing-wrapper .product-listing.block .article-content .link {
     display: flex;
     margin-bottom: 20px;
 }
 
-.product-listing.block .article-content .link a {
+.product-listing-wrapper .product-listing.block .article-content .link a {
     background-color: #ed3e49;
     color: #fff;
     border: 0.5px solid #ed3e49;
@@ -129,19 +129,19 @@
     transition-duration: .25s;
 }
 
-.product-listing.block .article-content .link a:hover {
+.product-listing-wrapper .product-listing.block .article-content .link a:hover {
     background-color: #151517;
     color: #fff;
     border-color: #151517;
 }
 
-.product-listing.block .article-content .disclaimer {
+.product-listing-wrapper .product-listing.block .article-content .disclaimer {
     font-size: 10px;
     color: #7d8fa0;
     margin-bottom: 35px;
 }
 
-.product-listing.block .article-content picture img {
+.product-listing-wrapper .product-listing.block .article-content picture img {
     width: 100%;
     height: auto;
 }

--- a/blocks/series-cards/series-cards.css
+++ b/blocks/series-cards/series-cards.css
@@ -1,10 +1,10 @@
-.series-cards.video-article.block {
+.series-cards-wrapper .series-cards.block {
   margin-top: 74px;
   width: 100%;
   text-decoration: none;
 }
 
-.series-cards.video-article.block .series-cards-content {
+.series-cards-wrapper .series-cards.block .series-cards-content {
   padding: 0 15px;
   max-width: 1440px;
   display: grid;
@@ -13,11 +13,11 @@
   margin: 0 auto;
 }
 
-.series-cards.video-article.block .series-card-wrapper {
+.series-cards-wrapper .series-cards.block .series-card-wrapper {
   background-color: #1f2022;
 }
 
-.series-cards.video-article.block .card-link {
+.series-cards-wrapper .series-cards.block .card-link {
   width: 100%;
   height: 100%;
   display: flex;
@@ -25,22 +25,22 @@
   text-decoration: none;
 }
 
-.series-cards.video-article.block .card-link:hover {
+.series-cards-wrapper .series-cards.block .card-link:hover {
   text-decoration: none;
 }
 
-.series-cards.video-article.block .series-card-wrapper .image-wrapper {
+.series-cards-wrapper .series-cards.block .series-card-wrapper .image-wrapper {
   overflow: hidden;
   width: 100%;
   aspect-ratio: 16/9;
 }
 
-.series-cards.video-article.block .series-card-wrapper .image-wrapper picture {
+.series-cards-wrapper .series-cards.block .series-card-wrapper .image-wrapper picture {
   height: 100%;
   width: 100%;
 }
 
-.series-cards.video-article.block .series-card-wrapper .image-wrapper img {
+.series-cards-wrapper .series-cards.block .series-card-wrapper .image-wrapper img {
   height: 100%;
   width: 100%;
   object-fit: cover;
@@ -49,15 +49,15 @@
   color: #fff;
 }
 
-.series-cards.video-article.block .series-card-wrapper .card-link:hover .image-wrapper img {
+.series-cards-wrapper .series-cards.block .series-card-wrapper .card-link:hover .image-wrapper img {
   transform: scale(1.2);
 }
 
-.series-cards.video-article.block .series-card-wrapper .title-wrapper {
+.series-cards-wrapper .series-cards.block .series-card-wrapper .title-wrapper {
   padding: 20px;
 }
 
-.series-cards.video-article.block .series-card-wrapper .title-span {
+.series-cards-wrapper .series-cards.block .series-card-wrapper .title-span {
   display: block;
   color: #fff;
   font-family: var(--font-gotham);
@@ -69,7 +69,7 @@
 }
 
 @media (max-width: 1024px) {
-  .series-cards.video-article.block .series-cards-content {
+  .series-cards-wrapper .series-cards.block .series-cards-content {
     grid-template-columns: 1fr 1fr;
     grid-row-gap: 24px;
     padding: 0;
@@ -77,29 +77,29 @@
 }
 
 @media (max-width: 768px) {
-  .series-cards.video-article.block .series-cards-content {
+  .series-cards-wrapper .series-cards.block .series-cards-content {
     grid-template-columns: 1fr;
     grid-row-gap: 1px;
   }
 
-  .series-cards.video-article.block .card-link {
+  .series-cards-wrapper .series-cards.block .card-link {
     padding: 15px 18px 20px;
     flex-direction: row;
   }
   
-  .series-cards.video-article.block .series-card-wrapper .image-wrapper {
+  .series-cards-wrapper .series-cards.block .series-card-wrapper .image-wrapper {
     overflow: hidden;
     width: 132px;
     height: 85px;
     aspect-ratio: unset;
   }
 
-  .series-cards.video-article.block .series-card-wrapper .title-wrapper {
+  .series-cards-wrapper .series-cards.block .series-card-wrapper .title-wrapper {
     padding-top: 0;
     flex: 1;
   }
   
-  .series-cards.video-article.block .series-card-wrapper .title-span {
+  .series-cards-wrapper .series-cards.block .series-card-wrapper .title-span {
     font-size: 14px;
   }
 }

--- a/blocks/text-box/text-box.css
+++ b/blocks/text-box/text-box.css
@@ -1,27 +1,27 @@
-.text-box.block {
+.text-box-wrapper .text-box.block {
   max-width: 1024px;
   margin: 0 auto;
 }
 
-.text-box.block .text-box-content {
+.text-box-wrapper .text-box.block .text-box-content {
   padding: 40px 80px;
   background-color: rgb(223 223 223);
   color: #000;
   margin: 0 15px 14px;
 }
 
-.text-box.block.dark .text-box-content {
+.text-box-wrapper .text-box.block.dark .text-box-content {
   background-color: #1f2022;
   color: #fff;
 }
 
-.text-box.block .text-box-content * {
+.text-box-wrapper .text-box.block .text-box-content * {
   margin: 0;
 }
 
-.text-box.block .text-box-content h1,
-.text-box.block .text-box-content h2,
-.text-box.block .text-box-content h3 {
+.text-box-wrapper .text-box.block .text-box-content h1,
+.text-box-wrapper .text-box.block .text-box-content h2,
+.text-box-wrapper .text-box.block .text-box-content h3 {
   font-weight: 600;
   display: flex;
   align-items: center;
@@ -32,9 +32,9 @@
   margin-bottom: 25px;
 }
 
-.text-box.block .text-box-content h1::before,
-.text-box.block .text-box-content h2::before,
-.text-box.block .text-box-content h3::before {
+.text-box-wrapper .text-box.block .text-box-content h1::before,
+.text-box-wrapper .text-box.block .text-box-content h2::before,
+.text-box-wrapper .text-box.block .text-box-content h3::before {
   content: "";
   display: block;
   width: 5px;
@@ -43,7 +43,7 @@
   background-color: #ed3e49;
 }
 
-.text-box.block .text-box-content p {
+.text-box-wrapper .text-box.block .text-box-content p {
   text-align: left;
   font-size: 16px;
   line-height: 25.6px;
@@ -51,26 +51,26 @@
 }
 
 @media (max-width: 1280px) {
-  .text-box.block .text-box-content h1,
-  .text-box.block .text-box-content h2,
-  .text-box.block .text-box-content h3 {
+  .text-box-wrapper .text-box.block .text-box-content h1,
+  .text-box-wrapper .text-box.block .text-box-content h2,
+  .text-box-wrapper .text-box.block .text-box-content h3 {
     font-size: 24px;
     padding: 0 15px;
   }
   
-  .text-box.block .text-box-content p {
+  .text-box-wrapper .text-box.block .text-box-content p {
     margin: 0 24px;
   }
 }
 
 @media (max-width: 1024px) {
-  .text-box.block .text-box-content {
+  .text-box-wrapper .text-box.block .text-box-content {
     padding: 20px 15px;
   }
 }
 
 @media (max-width: 768px) {
-  .text-box.block .text-box-content {
+  .text-box-wrapper .text-box.block .text-box-content {
     margin: 0 15px 14px;
   }
 }

--- a/blocks/tiger-cards/tiger-cards.css
+++ b/blocks/tiger-cards/tiger-cards.css
@@ -1,4 +1,4 @@
-.tiger-cards.block {
+.tiger-cards-wrapper .tiger-cards.block {
   display: flex;
   flex-direction: column;
   gap: 24px;
@@ -11,22 +11,22 @@
 
 }
 
-.tiger-cards.block .tiger-card-wrapper {
+.tiger-cards-wrapper .tiger-cards.block .tiger-card-wrapper {
   background-color: #1f2022;
 }
 
-.tiger-cards.block .tiger-card-wrapper .card-link {
+.tiger-cards-wrapper .tiger-cards.block .tiger-card-wrapper .card-link {
   display: flex;
   text-decoration: none;
 }
 
-.tiger-cards.block .tiger-card-wrapper .image-wrapper {
+.tiger-cards-wrapper .tiger-cards.block .tiger-card-wrapper .image-wrapper {
   position: relative;
   width: 356px;
   height: 200px;
 }
 
-.tiger-cards.block .tiger-card-wrapper .timestamp-wrapper {
+.tiger-cards-wrapper .tiger-cards.block .tiger-card-wrapper .timestamp-wrapper {
   transition: border-radius 0.2s, margin-right 0.2s, width 0.2s;
   border-radius: 15px;
   height: 20px;
@@ -44,48 +44,48 @@
   width: 45px;
 }
 
-.tiger-cards.block .tiger-card-wrapper:hover .timestamp-wrapper {
+.tiger-cards-wrapper .tiger-cards.block .tiger-card-wrapper:hover .timestamp-wrapper {
   border-radius: 5px;
   margin-right: 12.5px;
   width: 30px;
 }
 
-.tiger-cards.block .tiger-card-wrapper .timestamp-wrapper .timestamp {
+.tiger-cards-wrapper .tiger-cards.block .tiger-card-wrapper .timestamp-wrapper .timestamp {
   display: block;
   font-size: 10px;
   color: #fff;
 }
 
-.tiger-cards.block .tiger-card-wrapper .timestamp-wrapper .play-icon {
+.tiger-cards-wrapper .tiger-cards.block .tiger-card-wrapper .timestamp-wrapper .play-icon {
   display: none;
   margin-top: 2px;
 }
 
-.tiger-cards.block .tiger-card-wrapper:hover .timestamp-wrapper .timestamp {
+.tiger-cards-wrapper .tiger-cards.block .tiger-card-wrapper:hover .timestamp-wrapper .timestamp {
   display: none;
 }
 
-.tiger-cards.block .tiger-card-wrapper:hover .timestamp-wrapper .play-icon {
+.tiger-cards-wrapper .tiger-cards.block .tiger-card-wrapper:hover .timestamp-wrapper .play-icon {
   display: block;
 }
 
-.tiger-cards.block .tiger-card-wrapper .image-wrapper picture {
+.tiger-cards-wrapper .tiger-cards.block .tiger-card-wrapper .image-wrapper picture {
   width: 100%;
   height: 100%;
 }
 
-.tiger-cards.block .tiger-card-wrapper .image-wrapper img {
+.tiger-cards-wrapper .tiger-cards.block .tiger-card-wrapper .image-wrapper img {
   width: 100%;
   height: 100%;
 }
 
-.tiger-cards.block .tiger-card-wrapper .text-wrapper {
+.tiger-cards-wrapper .tiger-cards.block .tiger-card-wrapper .text-wrapper {
   padding: 20px;
   padding-right: 80px;
   flex: 1;
 }
 
-.tiger-cards.block .tiger-card-wrapper .text-wrapper .title-span {
+.tiger-cards-wrapper .tiger-cards.block .tiger-card-wrapper .text-wrapper .title-span {
   display: block;
   color: #fff;
   font-family: var(--font-gotham);
@@ -96,7 +96,7 @@
   margin-bottom: 10px;
 }
 
-.tiger-cards.block .tiger-card-wrapper .text-wrapper .description {
+.tiger-cards-wrapper .tiger-cards.block .tiger-card-wrapper .text-wrapper .description {
   margin: 0;
   font-family: var(--font-gotham);
   font-size: 14px;
@@ -105,41 +105,41 @@
 }
 
 @media (max-width: 1024px) {
-  .tiger-cards.block {
+  .tiger-cards-wrapper .tiger-cards.block {
     gap: 14px;
   }
 
-  .tiger-cards.block .tiger-card-wrapper .image-wrapper {
+  .tiger-cards-wrapper .tiger-cards.block .tiger-card-wrapper .image-wrapper {
     width: 230px;
     height: 130px;
   }
 
-  .tiger-cards.block .tiger-card-wrapper .text-wrapper {
+  .tiger-cards-wrapper .tiger-cards.block .tiger-card-wrapper .text-wrapper {
     padding: 15px;
   }
 
-  .tiger-cards.block .tiger-card-wrapper .text-wrapper .title-span {
+  .tiger-cards-wrapper .tiger-cards.block .tiger-card-wrapper .text-wrapper .title-span {
     font-size: 16px;
   }
 }
 
 @media (max-width: 768px) {
-  .tiger-cards.block {
+  .tiger-cards-wrapper .tiger-cards.block {
     gap: 0;
     margin: 0;
   }
 
-  .tiger-cards.block .tiger-card-wrapper .image-wrapper {
+  .tiger-cards-wrapper .tiger-cards.block .tiger-card-wrapper .image-wrapper {
     width: 150px;
     height: 84px;
     margin: 15px 0 15px 18px;
   }
 
-  .tiger-cards.block .tiger-card-wrapper .text-wrapper {
+  .tiger-cards-wrapper .tiger-cards.block .tiger-card-wrapper .text-wrapper {
     padding: 15px;
   }
 
-  .tiger-cards.block .tiger-card-wrapper .text-wrapper .title-span {
+  .tiger-cards-wrapper .tiger-cards.block .tiger-card-wrapper .text-wrapper .title-span {
     font-size: 14px;
   }
 }


### PR DESCRIPTION
 added block-wrapper selector to css selectors to prevent certain block variations from breaking

Fix #240

Test URLs:
- Before: https://main--helix-sportsmagazine--headwirecom.hlx.page
- After: https://block-css-selector-fix--helix-sportsmagazine--headwirecom.hlx.page


- Before: https://main--helix-sportsmagazine--headwirecom.hlx.page/golf-news-tours/features-test
- After: https://block-css-selector-fix--helix-sportsmagazine--headwirecom.hlx.page/golf-news-tours/features-test
