### PR TITLE
Re-adding ceros placeholder embed functionality

### DIFF
--- a/blocks/embed/embed.css
+++ b/blocks/embed/embed.css
@@ -3,6 +3,7 @@ main .embed {
     text-align: center;
     max-width: 800px;
     margin: 32px auto;
+    position: relative;
 }
 
 main .embed > div {
@@ -21,7 +22,8 @@ main .embed .embed-placeholder {
     position: relative;
 }
 
-main .embed .embed-placeholder > * {
+main .embed .embed-placeholder > picture,
+main .embed .embed-placeholder > .embed-placeholder-play {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -30,6 +32,15 @@ main .embed .embed-placeholder > * {
     left: 0;
     right: 0;
     bottom: 0;
+}
+
+main .embed .embed-placeholder.hide-play-button .embed-placeholder-play {
+    display: none;
+}
+
+main .embed.ceros-loading.embed-is-loaded .embed-placeholder > picture,
+main .embed.ceros-loading.embed-is-loaded .embed-placeholder > .embed-placeholder-play {
+    display: none;
 }
 
 main .embed .embed-placeholder picture img {
@@ -68,10 +79,15 @@ main .embed.block:has(div > iframe, iframe) {
     max-width: 100%;
 }
 
-main .embed.block:has(iframe[src^="https://view.ceros.com/golf-digest/"]) {
+main .embed.block[data-embed-link^="https://view.ceros.com/golf-digest/"] {
     max-width: var(--layout-width);
 }
 
+main .embed.block[data-embed-link^="https://view.ceros.com/golf-digest/"]:not(:has(.embed-placeholder)) {
+    aspect-ratio: 16/9;
+}
+
+main .embed.block[data-embed-link^="https://view.ceros.com/golf-digest/"] .embed-placeholder picture,
 main .embed.block iframe[src^="https://view.ceros.com/golf-digest/"] {
     padding: 0 15px;
 }


### PR DESCRIPTION
Fixing Ceros embed CSS.
All embeds without a placeholder now load on first scroll.
Ceros embeds with a placeholder will start loading on scroll, but show the placeholder for 2 seconds while they load, after the placeholder will no longer be shown.
Ceros embeds without placeholders will load on first scroll like normal, and now also have some CSS to avoid some layout shift.

re-adds functionality removed from reverting PR #246 

Test URLs:
Landing page, every embed has placeholders
- Before: https://main--helix-sportsmagazine--headwirecom.hlx.page
- After: https://ceros-embed-functionality--helix-sportsmagazine--headwirecom.hlx.page

These pages use non 16/9 sized ceros embeds.
- Before: https://main--helix-sportsmagazine--headwirecom.hlx.page/privacy-and-cookies-notice-uk-eu
- After: https://ceros-embed-functionality--helix-sportsmagazine--headwirecom.hlx.page/privacy-and-cookies-notice-uk-eu

This page has a twitter embed. This should look unchanged.
- Before: https://main--helix-sportsmagazine--headwirecom.hlx.page/content-v2/the-loop/_default/article/2019/3/players-championship-2019-twitter-all-star-eddie-pepperell-says-twitter-is-everything-i-despise-about-life
- After: https://ceros-embed-functionality--helix-sportsmagazine--headwirecom.hlx.page/content-v2/the-loop/_default/article/2019/3/players-championship-2019-twitter-all-star-eddie-pepperell-says-twitter-is-everything-i-despise-about-life

A test page using ceros embeds with no placeholder
- Before: https://main--helix-sportsmagazine--headwirecom.hlx.page/drafts/ringel/test3
- After: https://ceros-embed-functionality--helix-sportsmagazine--headwirecom.hlx.page/drafts/ringel/test3