### PR TITLE
Query initialization fixes

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -557,7 +557,7 @@ window.store = new (class {
     this._blockQueryLimit = {
       hero: (block) => {
         const firstHero = document.querySelector('.hero.block[data-block-name="hero"]');
-        if (firstHero?.isEqualNode(block)) {
+        if (firstHero.isEqualNode(block)) {
           return 4;
         }
         return 1;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -557,7 +557,8 @@ window.store = new (class {
     this._blockQueryLimit = {
       hero: (block) => {
         const firstHero = document.querySelector('.hero.block[data-block-name="hero"]');
-        if (firstHero.isEqualNode(block)) {
+        debugger
+        if (firstHero?.isEqualNode(block)) {
           return 4;
         }
         return 1;
@@ -628,7 +629,7 @@ window.store = new (class {
     this.blockNames.forEach((blockName) => {
       queryNames.forEach((queryName) => {
         const { spreadsheet } = this._queryMap[queryName];
-        document.querySelectorAll(`main .${blockName}.${queryName}-${spreadsheet}.block`).forEach((blockEl) => {
+        document.querySelectorAll(`main .${queryName}-${spreadsheet}.block[data-block-name="${blockName}"]`).forEach((blockEl) => {
           this._queryMap[queryName].limit += this._blockQueryLimit[blockName](blockEl);
         });
       });

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -557,7 +557,6 @@ window.store = new (class {
     this._blockQueryLimit = {
       hero: (block) => {
         const firstHero = document.querySelector('.hero.block[data-block-name="hero"]');
-        debugger
         if (firstHero?.isEqualNode(block)) {
           return 4;
         }
@@ -613,11 +612,13 @@ window.store = new (class {
           .find((className) => className.endsWith(spreadsheet));
 
         if (queryClassName) {
-          const query = queryClassName.replace(`-${spreadsheet}`, '');
-          if (!this._queryMap[query]) {
-            this._queryMap[query] = {
+          const sheetName = queryClassName.replace(`-${spreadsheet}`, '');
+          if (!this._queryMap[queryClassName]) {
+            this._queryMap[queryClassName] = {
               spreadsheet,
+              sheetName,
               limit: 0,
+              query: queryClassName,
             };
           }
         }
@@ -628,8 +629,7 @@ window.store = new (class {
     const queryNames = Object.keys(this._queryMap);
     this.blockNames.forEach((blockName) => {
       queryNames.forEach((queryName) => {
-        const { spreadsheet } = this._queryMap[queryName];
-        document.querySelectorAll(`main .${queryName}-${spreadsheet}.block[data-block-name="${blockName}"]`).forEach((blockEl) => {
+        document.querySelectorAll(`main .${queryName}.block[data-block-name="${blockName}"]`).forEach((blockEl) => {
           this._queryMap[queryName].limit += this._blockQueryLimit[blockName](blockEl);
         });
       });
@@ -692,7 +692,7 @@ Make sure to set a limit for \x1b[31m"${block.dataset.blockName}"\x1b[0m in \x1b
       url = queryDetails.mock;
     } else {
       // Build query sheet url
-      url = `/${this._spreadsheets[queryDetails.spreadsheet]}.json?sheet=${query}`;
+      url = `/${this._spreadsheets[queryDetails.spreadsheet]}.json?sheet=${queryDetails.sheetName}`;
     }
 
     const dispatchData = (dispatchId) => {


### PR DESCRIPTION
Adjusted query initialization queryselectos, so block variations that share a name with a block-type, won't get the wrong limits.

Adjusted generated querymap to name object keys using both spreadsheet name and sheet names so blocks with matching sheet names but differing spreadsheets will no longer break eachothers queries.

Fix #248 
Fix #249 

Test URLs:
- Before: https://main--helix-sportsmagazine--headwirecom.hlx.page
- After: https://query-initialization-fix--helix-sportsmagazine--headwirecom.hlx.page

- Before: https://main--helix-sportsmagazine--headwirecom.hlx.page/drafts/ringel/test2
- After: https://query-initialization-fix--helix-sportsmagazine--headwirecom.hlx.page/drafts/ringel/test2
