### PR TITLE
404 page redirects fitting vanity paths to the long-form url

### DIFF
--- a/404.html
+++ b/404.html
@@ -183,7 +183,6 @@
       import sitemap from "/import/tools/importer/data/sitemap.json" assert {type: 'json'}
 
       const pathLocation = sitemap.find((obj) => Object.hasOwn(obj, window.location.pathname))
-      // debugger
       if (pathLocation) {
         const drivePath = '/content-v2/' + pathLocation[window.location.pathname].replace('/content/golfdigest-com/en/', '').replace('.html', '')
         window.location.assign(drivePath)

--- a/404.html
+++ b/404.html
@@ -180,21 +180,28 @@
     <footer></footer>
     <script type="module">
       import { createOptimizedPicture } from "/scripts/lib-franklin.js";
-      import sitemap from "/import/tools/importer/data/sitemap.json" assert {type: 'json'}
 
-      const pathLocation = sitemap.find((obj) => Object.hasOwn(obj, window.location.pathname))
-      if (pathLocation) {
-        const drivePath = '/content-v2/' + pathLocation[window.location.pathname].replace('/content/golfdigest-com/en/', '').replace('.html', '')
-        window.location.assign(drivePath)
-      } else {
-        document.body.hidden = false
-  
-        const imageUrl = "/media_10b8f0c21a329ee5ab764abf34d64a94de757ea2a.png";
-        const imageAlt = "Tiger Woods regretting a bad shot";
-        const pictureElement = createOptimizedPicture(imageUrl, imageAlt);
-        const imageContainer = document.querySelector(".error-image");
-        imageContainer.appendChild(pictureElement);
+      const display404 = () => {
+          document.body.hidden = false
+    
+          const imageUrl = "/media_10b8f0c21a329ee5ab764abf34d64a94de757ea2a.png";
+          const imageAlt = "Tiger Woods regretting a bad shot";
+          const pictureElement = createOptimizedPicture(imageUrl, imageAlt);
+          const imageContainer = document.querySelector(".error-image");
+          imageContainer.appendChild(pictureElement);
       }
+      
+      fetch('/import/tools/importer/data/sitemap.json').then(response => response.json()).then((sitemap) => {
+        const pathLocation = sitemap.find((obj) => Object.hasOwn(obj, window.location.pathname))
+        if (pathLocation) {
+          const drivePath = '/content-v2/' + pathLocation[window.location.pathname].replace('/content/golfdigest-com/en/', '').replace('.html', '')
+          window.location.assign(drivePath)
+        } else {
+          display404()
+        }
+      }).catch(error => {
+        display404()
+      })
     </script>
   </body>
 </html>

--- a/404.html
+++ b/404.html
@@ -157,7 +157,7 @@
     </style>
   </head>
 
-  <body>
+  <body hidden>
     <header></header>
     <main class="error">
       <section>
@@ -179,12 +179,23 @@
     </main>
     <footer></footer>
     <script type="module">
-      import { createOptimizedPicture } from "./scripts/lib-franklin.js";
-      const imageUrl = "/media_10b8f0c21a329ee5ab764abf34d64a94de757ea2a.png";
-      const imageAlt = "Tiger Woods regretting a bad shot";
-      const pictureElement = createOptimizedPicture(imageUrl, imageAlt);
-      const imageContainer = document.querySelector(".error-image");
-      imageContainer.appendChild(pictureElement);
+      import { createOptimizedPicture } from "/scripts/lib-franklin.js";
+      import sitemap from "/import/tools/importer/data/sitemap.json" assert {type: 'json'}
+
+      const pathLocation = sitemap.find((obj) => Object.hasOwn(obj, window.location.pathname))
+      // debugger
+      if (pathLocation) {
+        const drivePath = '/content-v2/' + pathLocation[window.location.pathname].replace('/content/golfdigest-com/en/', '').replace('.html', '')
+        window.location.assign(drivePath)
+      } else {
+        document.body.hidden = false
+  
+        const imageUrl = "/media_10b8f0c21a329ee5ab764abf34d64a94de757ea2a.png";
+        const imageAlt = "Tiger Woods regretting a bad shot";
+        const pictureElement = createOptimizedPicture(imageUrl, imageAlt);
+        const imageContainer = document.querySelector(".error-image");
+        imageContainer.appendChild(pictureElement);
+      }
     </script>
   </body>
 </html>

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -30,6 +30,17 @@ const LCP_BLOCKS = [...Object.values(ARTICLE_TEMPLATES), 'hero']; // add your LC
 
 const range = document.createRange();
 
+// getting real path, and adjusting canonical link to use the vanity path
+const canonicalLinkTag = document.head.querySelector('link[rel="canonical"]');
+if (canonicalLinkTag) {
+  const longPathMetadata = document.createElement('meta');
+  longPathMetadata.setAttribute('property', 'hlx:long-form-path');
+  longPathMetadata.content = canonicalLinkTag?.href;
+  document.head.appendChild(longPathMetadata);
+  window.canonicalLocation = canonicalLinkTag.href;
+  canonicalLinkTag.href = window.location.href;
+}
+
 export function replaceLinksWithEmbed(block) {
   const embeds = ['youtube', 'brightcove', 'instagram', 'ceros'];
   block.querySelectorAll(embeds.map((embed) => `a:only-child[href*="${embed}"]`).join(',')).forEach((embedLink) => {
@@ -398,7 +409,7 @@ export function addFavIcons() {
   `;
 
   // Remove placeholder
-  document.head.querySelector('head link[rel="icon"]').remove();
+  document.head.querySelector('head link[rel="icon"]')?.remove();
 
   // Add favicons
   document.head.insertAdjacentHTML('beforeend', favicons);


### PR DESCRIPTION
404 page now checks if the current path could be a vanity path for an existing path that was not re-routed

Test URLs:
- Before: https://main--helix-sportsmagazine--headwirecom.hlx.page/story/phil-mickelson-tweet-pga-tour-liv-merger
- After: https://404-vanity-redirect--helix-sportsmagazine--headwirecom.hlx.page/story/phil-mickelson-tweet-pga-tour-liv-merger
